### PR TITLE
Added D-Bus type AST representation and parsing and support for the <node> element.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -36,6 +36,8 @@ class Type(object):
 
     """
     AST representation of a D-Bus type.
+
+    See http://dbus.freedesktop.org/doc/dbus-specification.html#type-system
     """
 
     def __init__(self):
@@ -322,6 +324,8 @@ class TypeSignature(object):
 
     """
     AST representation of a D-Bus signature.
+
+    See http://dbus.freedesktop.org/doc/dbus-specification.html#type-system
     """
 
     def __init__(self):
@@ -442,14 +446,14 @@ class Property(object):
     ACCESS_WRITE = 'write'
     ACCESS_READWRITE = 'readwrite'
 
-    def __init__(self, name, prop_type, access, annotations=None):
+    def __init__(self, name, signature, access, annotations=None):
         """
         Construct a new ast.Property.
 
         Args:
             name: property name; a non-empty string, not including the parent
                 interface name
-            prop_type: type string for the property; see http://goo.gl/uCpa5A
+            signature: TypeSignature instance
             access: ACCESS_READ, ACCESS_WRITE, or ACCESS_READWRITE
             annotations: potentially empty dict of annotations applied to the
                 property, mapping annotation name to an ast.Annotation
@@ -459,7 +463,7 @@ class Property(object):
             annotations = {}
 
         self.name = name
-        self.type = prop_type
+        self.signature = signature
         self.access = access
         self.interface = None
         self.annotations = annotations
@@ -588,14 +592,14 @@ class Argument(object):
     DIRECTION_IN = 'in'
     DIRECTION_OUT = 'out'
 
-    def __init__(self, name, direction, arg_type, annotations=None):
+    def __init__(self, name, direction, signature, annotations=None):
         """
         Construct a new ast.Argument.
 
         Args:
             name: argument name; may be empty
             direction: DIRECTION_IN or DIRECTION_OUT
-            arg_type: type string for the argument; see http://goo.gl/uCpa5A
+            signature: TypeSignature instance for the argument
             annotations: potentially empty dict of annotations applied to the
                 argument, mapping annotation name to an ast.Annotation
                 instance
@@ -605,7 +609,7 @@ class Argument(object):
 
         self.name = name
         self.direction = direction
-        self.type = arg_type
+        self.signature = signature
         self.index = -1
         self.parent = None
         self.annotations = annotations

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -51,8 +51,8 @@ class Type(object):
         return self.type
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__)
-            and self.__dict__ == other.__dict__)
+        return (isinstance(other, self.__class__) and
+                self.__dict__ == other.__dict__)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -344,8 +344,8 @@ class TypeSignature(object):
         return "".join(map(str, self.members))
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__)
-            and self.__dict__ == other.__dict__)
+        return (isinstance(other, self.__class__) and
+                self.__dict__ == other.__dict__)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -391,7 +391,6 @@ class Node(object):
         return self.name
 
 
-# pylint: disable=interface-not-implemented
 class Interface(object):
 
     """
@@ -460,14 +459,14 @@ class Property(object):
     ACCESS_WRITE = 'write'
     ACCESS_READWRITE = 'readwrite'
 
-    def __init__(self, name, type, access, annotations=None):
+    def __init__(self, name, prop_type, access, annotations=None):
         """
         Construct a new ast.Property.
 
         Args:
             name: property name; a non-empty string, not including the parent
                 interface name
-            type: TypeSignature instance
+            prop_type: TypeSignature instance
             access: ACCESS_READ, ACCESS_WRITE, or ACCESS_READWRITE
             annotations: potentially empty dict of annotations applied to the
                 property, mapping annotation name to an ast.Annotation
@@ -477,7 +476,7 @@ class Property(object):
             annotations = {}
 
         self.name = name
-        self.type = type
+        self.type = prop_type
         self.access = access
         self.interface = None
         self.annotations = annotations
@@ -606,14 +605,14 @@ class Argument(object):
     DIRECTION_IN = 'in'
     DIRECTION_OUT = 'out'
 
-    def __init__(self, name, direction, type, annotations=None):
+    def __init__(self, name, direction, arg_type, annotations=None):
         """
         Construct a new ast.Argument.
 
         Args:
             name: argument name; may be empty
             direction: DIRECTION_IN or DIRECTION_OUT
-            type: TypeSignature instance for the argument
+            arg_type: TypeSignature instance for the argument
             annotations: potentially empty dict of annotations applied to the
                 argument, mapping annotation name to an ast.Annotation
                 instance
@@ -623,7 +622,7 @@ class Argument(object):
 
         self.name = name
         self.direction = direction
-        self.type = type
+        self.type = arg_type
         self.index = -1
         self.parent = None
         self.annotations = annotations

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -34,6 +34,10 @@ TODO
 
 class Type(object):
 
+    """
+    AST representation of a D-Bus type.
+    """
+
     def __init__(self):
         """Constructor."""
         self.type = "\0"
@@ -47,6 +51,10 @@ class Type(object):
 
 class Byte(Type):
 
+    """
+    AST representation of the D-Bus BYTE type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -56,6 +64,10 @@ class Byte(Type):
 
 
 class Boolean(Type):
+
+    """
+    AST representation of the D-Bus BOOLEAN type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -67,6 +79,10 @@ class Boolean(Type):
 
 class Int16(Type):
 
+    """
+    AST representation of the D-Bus INT16 type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -76,6 +92,10 @@ class Int16(Type):
 
 
 class UInt16(Type):
+
+    """
+    AST representation of the D-Bus UINT16 type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -87,6 +107,10 @@ class UInt16(Type):
 
 class Int32(Type):
 
+    """
+    AST representation of the D-Bus INT32 type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -96,6 +120,10 @@ class Int32(Type):
 
 
 class UInt32(Type):
+
+    """
+    AST representation of the D-Bus UINT32 type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -107,6 +135,10 @@ class UInt32(Type):
 
 class Int64(Type):
 
+    """
+    AST representation of the D-Bus INT64 type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -116,6 +148,10 @@ class Int64(Type):
 
 
 class UInt64(Type):
+
+    """
+    AST representation of the D-Bus UINT64 type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -127,6 +163,10 @@ class UInt64(Type):
 
 class Double(Type):
 
+    """
+    AST representation of the D-Bus DOUBLE type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -136,6 +176,10 @@ class Double(Type):
 
 
 class String(Type):
+
+    """
+    AST representation of the D-Bus STRING type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -147,6 +191,10 @@ class String(Type):
 
 class ObjectPath(Type):
 
+    """
+    AST representation of the D-Bus OBJECT_PATH type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -156,6 +204,10 @@ class ObjectPath(Type):
 
 
 class Signature(Type):
+
+    """
+    AST representation of the D-Bus SIGNATURE type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -167,6 +219,10 @@ class Signature(Type):
 
 class Variant(Type):
 
+    """
+    AST representation of the D-Bus VARIANT type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -177,6 +233,10 @@ class Variant(Type):
 
 class UnixFD(Type):
 
+    """
+    AST representation of the D-Bus UNIX_FD type.
+    """
+
     def __init__(self):
         """Constructor."""
         Type.__init__(self)
@@ -186,6 +246,10 @@ class UnixFD(Type):
 
 
 class Container(Type):
+
+    """
+    AST representation of the D-Bus container type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -198,6 +262,10 @@ class Container(Type):
 
 
 class Array(Container):
+
+    """
+    AST representation of the D-Bus ARRAY type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -214,6 +282,10 @@ class Array(Container):
 
 class Struct(Container):
 
+    """
+    AST representation of the D-Bus STRUCT type.
+    """
+
     def __init__(self):
         """Constructor."""
         Container.__init__(self)
@@ -227,6 +299,10 @@ class Struct(Container):
 
 
 class DictEntry(Container):
+
+    """
+    AST representation of the D-Bus DICT_ENTRY type.
+    """
 
     def __init__(self):
         """Constructor."""
@@ -242,7 +318,11 @@ class DictEntry(Container):
         return "{{{}{}}}".format(key, val)
 
 
-class Signature(object):
+class TypeSignature(object):
+
+    """
+    AST representation of a D-Bus signature.
+    """
 
     def __init__(self):
         """Constructor."""

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -32,6 +32,205 @@ TODO
 # pylint: disable=too-few-public-methods
 
 
+class Type(object):
+
+    def __init__(self):
+        """Constructor."""
+        self.type = "\0"
+        self.name = "INVALID"
+        self.alignment = 1
+
+    def format_type(self):
+        """Format the type’s type as a human-readable string."""
+        return self.type
+
+    def format_name(self):
+        """Format the type’s name as a human-readable string."""
+        return self.name
+
+    def format_alignment(self):
+        """Format the type’s alignment as a human-readable string."""
+        return str(self.alignment)
+
+
+class Byte(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "y"
+        self.name = "BYTE"
+        self.alignment = 1
+
+
+class Boolean(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "b"
+        self.name = "BOOLEAN"
+        self.alignment = 4
+
+
+class Int16(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "n"
+        self.name = "INT16"
+        self.alignment = 2
+
+
+class UInt16(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "q"
+        self.name = "UINT16"
+        self.alignment = 2
+
+
+class Int32(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "i"
+        self.name = "INT32"
+        self.alignment = 4
+
+
+class UInt32(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "u"
+        self.name = "UINT32"
+        self.alignment = 4
+
+
+class Int64(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "x"
+        self.name = "INT64"
+        self.alignment = 8
+
+
+class UInt64(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "t"
+        self.name = "UINT64"
+        self.alignment = 8
+
+
+class Double(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "d"
+        self.name = "DOUBLE"
+        self.alignment = 8
+
+
+class String(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "s"
+        self.name = "STRING"
+        self.alignment = 4
+
+
+class ObjectPath(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "o"
+        self.name = "OBJECT_PATH"
+        self.alignment = 4
+
+
+class Signature(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "g"
+        self.name = "SIGNATURE"
+        self.alignment = 1
+
+
+class Variant(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "v"
+        self.name = "VARIANT"
+        self.alignment = 1
+
+
+class UnixFD(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.type = "h"
+        self.name = "UNIX_FD"
+        self.alignment = 4
+
+
+class Container(Type):
+
+    def __init__(self):
+        """Constructor."""
+        Type.__init__(self)
+        self.members = []
+
+
+class Array(Container):
+
+    def __init__(self):
+        """Constructor."""
+        Container.__init__(self)
+        self.type = "a"
+        self.name = "ARRAY"
+        self.alignment = 4
+
+
+class Struct(Container):
+
+    def __init__(self):
+        """Constructor."""
+        Container.__init__(self)
+        self.type = "r"
+        self.name = "STRUCT"
+        self.alignment = 8
+
+
+class DictEntry(Container):
+
+    def __init__(self):
+        """Constructor."""
+        Container.__init__(self)
+        self.type = "e"
+        self.name = "DICT_ENTRY"
+        self.alignment = 8
+
+
 class Node(object):
 
     """

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -40,17 +40,9 @@ class Type(object):
         self.name = "INVALID"
         self.alignment = 1
 
-    def format_type(self):
-        """Format the type’s type as a human-readable string."""
+    def __str__(self):
+        """Format the type as a human-readable string."""
         return self.type
-
-    def format_name(self):
-        """Format the type’s name as a human-readable string."""
-        return self.name
-
-    def format_alignment(self):
-        """Format the type’s alignment as a human-readable string."""
-        return str(self.alignment)
 
 
 class Byte(Type):
@@ -200,6 +192,10 @@ class Container(Type):
         Type.__init__(self)
         self.members = []
 
+    def __str__(self):
+        """Format the type as a human-readable string."""
+        return "".join(map(str, self.members))
+
 
 class Array(Container):
 
@@ -209,6 +205,11 @@ class Array(Container):
         self.type = "a"
         self.name = "ARRAY"
         self.alignment = 4
+
+    def __str__(self):
+        """Format the type as a human-readable string."""
+        member = str(self.members[0]) if len(self.members) > 0 else "?"
+        return "{}{}".format(self.type, member)
 
 
 class Struct(Container):
@@ -220,6 +221,10 @@ class Struct(Container):
         self.name = "STRUCT"
         self.alignment = 8
 
+    def __str__(self):
+        """Format the type as a human-readable string."""
+        return "({})".format("".join(map(str, self.members)))
+
 
 class DictEntry(Container):
 
@@ -229,6 +234,23 @@ class DictEntry(Container):
         self.type = "e"
         self.name = "DICT_ENTRY"
         self.alignment = 8
+
+    def __str__(self):
+        """Format the type as a human-readable string."""
+        key = str(self.members[0]) if self.members > 0 else "?"
+        val = str(self.members[1]) if self.members > 1 else "?"
+        return "{{{}{}}}".format(key, val)
+
+
+class Signature(object):
+
+    def __init__(self):
+        """Constructor."""
+        self.members = []
+
+    def __str__(self):
+        """Format the type as a human-readable string."""
+        return "".join(map(str, self.members))
 
 
 class Node(object):
@@ -246,7 +268,7 @@ class Node(object):
 
         Args:
             name: node name; a non-empty string
-            intterfaces: potentially empty dict of interfaces in the node
+            interfaces: potentially empty dict of interfaces in the node
                 containing ast.Interface instances
             nodes: potentially empty dict of sub-nodes in the node
                 containing ast.Node instances

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -50,6 +50,13 @@ class Type(object):
         """Format the type as a human-readable string."""
         return self.type
 
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__)
+            and self.__dict__ == other.__dict__)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class Byte(Type):
 
@@ -336,6 +343,13 @@ class TypeSignature(object):
         """Format the type as a human-readable string."""
         return "".join(map(str, self.members))
 
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__)
+            and self.__dict__ == other.__dict__)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class Node(object):
 
@@ -446,14 +460,14 @@ class Property(object):
     ACCESS_WRITE = 'write'
     ACCESS_READWRITE = 'readwrite'
 
-    def __init__(self, name, signature, access, annotations=None):
+    def __init__(self, name, type, access, annotations=None):
         """
         Construct a new ast.Property.
 
         Args:
             name: property name; a non-empty string, not including the parent
                 interface name
-            signature: TypeSignature instance
+            type: TypeSignature instance
             access: ACCESS_READ, ACCESS_WRITE, or ACCESS_READWRITE
             annotations: potentially empty dict of annotations applied to the
                 property, mapping annotation name to an ast.Annotation
@@ -463,7 +477,7 @@ class Property(object):
             annotations = {}
 
         self.name = name
-        self.signature = signature
+        self.type = type
         self.access = access
         self.interface = None
         self.annotations = annotations
@@ -592,14 +606,14 @@ class Argument(object):
     DIRECTION_IN = 'in'
     DIRECTION_OUT = 'out'
 
-    def __init__(self, name, direction, signature, annotations=None):
+    def __init__(self, name, direction, type, annotations=None):
         """
         Construct a new ast.Argument.
 
         Args:
             name: argument name; may be empty
             direction: DIRECTION_IN or DIRECTION_OUT
-            signature: TypeSignature instance for the argument
+            type: TypeSignature instance for the argument
             annotations: potentially empty dict of annotations applied to the
                 argument, mapping annotation name to an ast.Annotation
                 instance
@@ -609,7 +623,7 @@ class Argument(object):
 
         self.name = name
         self.direction = direction
-        self.signature = signature
+        self.type = type
         self.index = -1
         self.parent = None
         self.annotations = annotations

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -32,13 +32,53 @@ TODO
 # pylint: disable=too-few-public-methods
 
 
+class Node(object):
+
+    """
+    AST representation of a <node> element.
+
+    This represents the top level of a D-Bus API.
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name=None, interfaces=None, nodes=None):
+        """
+        Construct a new ast.Node.
+
+        Args:
+            name: node name; a non-empty string
+            intterfaces: potentially empty dict of interfaces in the node
+                containing ast.Interface instances
+            nodes: potentially empty dict of sub-nodes in the node
+                containing ast.Node instances
+        """
+        if interfaces is None:
+            interfaces = {}
+        if nodes is None:
+            nodes = {}
+
+        self.node = None
+        self.name = name
+        self.interfaces = interfaces
+        self.nodes = nodes
+
+        for interface in self.interfaces.values():
+            interface.node = self
+        for node in self.nodes.values():
+            node.node = self
+
+    def format_name(self):
+        u"""Format the node’s name as a human-readable string."""
+        return self.name
+
+
 # pylint: disable=interface-not-implemented
 class Interface(object):
 
     """
     AST representation of an <interface> element.
 
-    This represents the top level of a D-Bus API.
+    This represents the most common node member of a D-Bus API.
     """
 
     # pylint: disable=too-many-arguments
@@ -68,6 +108,7 @@ class Interface(object):
         if annotations is None:
             annotations = {}
 
+        self.node = None
         self.name = name
         self.methods = methods
         self.properties = properties

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -390,13 +390,13 @@ class InterfaceParser(object):
                                    (node.tag, pretty_prop_name))
 
         type_parser = TypeParser(prop_type)
-        signature = type_parser.parse()
-        if not signature:
+        type = type_parser.parse()
+        if not type:
             self._issue_output('invalid-signature',
                                type_parser.get_output()[1])
             return None
 
-        return ast.Property(name, signature, access, annotations)
+        return ast.Property(name, type, access, annotations)
 
     def _parse_arg(self, arg_node, parent_name=None):
         """Parse an <arg> element; return an ast.Argument or None."""
@@ -431,13 +431,13 @@ class InterfaceParser(object):
                                    (node.tag, pretty_arg_name, parent_name))
 
         type_parser = TypeParser(arg_type)
-        signature = type_parser.parse()
-        if not signature:
+        type = type_parser.parse()
+        if not type:
             self._issue_output('invalid-signature',
                                type_parser.get_output()[1])
             return None
 
-        return ast.Argument(name, direction, signature, annotations)
+        return ast.Argument(name, direction, type, annotations)
 
     def _parse_annotation(self, annotation_node, parent_name=None):
         """Parse an <annotation> element; return an ast.Annotation or None."""

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -31,7 +31,6 @@ TODO
 import os
 
 # PyPy support
-# pylint: disable=interface-not-implemented
 try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
@@ -52,7 +51,6 @@ def _ignore_node(node):
     return node.tag[0] == '{'  # in a namespace
 
 
-# pylint: disable=interface-not-implemented
 class InterfaceParser(object):
 
     """
@@ -141,7 +139,8 @@ class InterfaceParser(object):
 
         if root_node.name and not root_node.name[0] == '/':
             self._issue_output('node-naming',
-                               'Root node name is not an absolute object path ‘%s’.' % root_node.name)
+                               'Root node name is not an absolute object path '
+                               '‘%s’.' % root_node.name)
             return None
 
         return root_node
@@ -177,12 +176,14 @@ class InterfaceParser(object):
 
                 if not sub_node.name:
                     self._issue_output('missing-attribute',
-                                       'Missing required attribute ‘name’ in non-root node.')
+                                       'Missing required attribute ‘name’ '
+                                       'in non-root node.')
                     continue
 
                 if sub_node.name[0] == '/':
                     self._issue_output('node-naming',
-                                       'Non-root node name is not a relative object path ‘%s’.' % sub_node.name)
+                                       'Non-root node name is not a relative '
+                                       'object path ‘%s’.' % sub_node.name)
                     continue
 
                 if sub_node.name in nodes:
@@ -390,13 +391,13 @@ class InterfaceParser(object):
                                    (node.tag, pretty_prop_name))
 
         type_parser = TypeParser(prop_type)
-        type = type_parser.parse()
-        if not type:
+        type_signature = type_parser.parse()
+        if not type_signature:
             self._issue_output('invalid-signature',
                                type_parser.get_output()[1])
             return None
 
-        return ast.Property(name, type, access, annotations)
+        return ast.Property(name, type_signature, access, annotations)
 
     def _parse_arg(self, arg_node, parent_name=None):
         """Parse an <arg> element; return an ast.Argument or None."""
@@ -431,13 +432,13 @@ class InterfaceParser(object):
                                    (node.tag, pretty_arg_name, parent_name))
 
         type_parser = TypeParser(arg_type)
-        type = type_parser.parse()
-        if not type:
+        type_signature = type_parser.parse()
+        if not type_signature:
             self._issue_output('invalid-signature',
                                type_parser.get_output()[1])
             return None
 
-        return ast.Argument(name, direction, type, annotations)
+        return ast.Argument(name, direction, type_signature, annotations)
 
     def _parse_annotation(self, annotation_node, parent_name=None):
         """Parse an <annotation> element; return an ast.Annotation or None."""

--- a/dbusapi/tests/test_ast.py
+++ b/dbusapi/tests/test_ast.py
@@ -218,9 +218,8 @@ class TestAstParenting(unittest.TestCase):
         self.assertEqual(annotation.parent, None)
 
         signature = TypeParser('s').parse()
-        arg = ast.Argument('SomeArgument', ast.Argument.DIRECTION_IN, signature, {
-            'SomeAnnotation': annotation,
-        })
+        arg = ast.Argument('SomeArgument', ast.Argument.DIRECTION_IN,
+                           signature, {'SomeAnnotation': annotation})
         self.assertEqual(arg.parent, None)
         self.assertEqual(arg.index, -1)
         self.assertEqual(annotation.parent, arg)

--- a/dbusapi/tests/test_ast.py
+++ b/dbusapi/tests/test_ast.py
@@ -33,6 +33,7 @@ Unit tests for dbusapi.ast
 
 
 from dbusapi import ast
+from dbusapi.typeparser import TypeParser
 import unittest
 
 
@@ -45,14 +46,16 @@ class TestAstNames(unittest.TestCase):
         self.assertEqual(iface.format_name(), 'SomeInterface')
 
     def test_property(self):
-        prop = ast.Property('AProperty', 's', ast.Property.ACCESS_READ)
+        signature = TypeParser('s').parse()
+        prop = ast.Property('AProperty', signature, ast.Property.ACCESS_READ)
         iface = ast.Interface('SomeInterface', {}, {
             'AProperty': prop,
         })
         self.assertEqual(prop.format_name(), 'SomeInterface.AProperty')
 
     def test_property_unparented(self):
-        prop = ast.Property('AProperty', 's', ast.Property.ACCESS_READ)
+        signature = TypeParser('s').parse()
+        prop = ast.Property('AProperty', signature, ast.Property.ACCESS_READ)
         self.assertEqual(prop.format_name(), 'AProperty')
 
     def test_method(self):
@@ -78,22 +81,26 @@ class TestAstNames(unittest.TestCase):
         self.assertEqual(signal.format_name(), 'SomeSignal')
 
     def test_argument(self):
-        arg = ast.Argument('self', ast.Argument.DIRECTION_IN, 's')
+        signature = TypeParser('s').parse()
+        arg = ast.Argument('self', ast.Argument.DIRECTION_IN, signature)
         method = ast.Method('ParentMethod', [arg])
         self.assertEqual(arg.format_name(), '0 (‘self’)')
 
     def test_argument_unparented(self):
-        arg = ast.Argument('self', ast.Argument.DIRECTION_IN, 's')
+        signature = TypeParser('s').parse()
+        arg = ast.Argument('self', ast.Argument.DIRECTION_IN, signature)
         self.assertEqual(arg.format_name(), '‘self’')
 
     def test_argument_unnamed(self):
-        arg = ast.Argument(None, ast.Argument.DIRECTION_IN, 's')
+        signature = TypeParser('s').parse()
+        arg = ast.Argument(None, ast.Argument.DIRECTION_IN, signature)
         method = ast.Method('ParentMethod', [arg])
         self.assertEqual(arg.format_name(), '0')
 
     # pylint: disable=invalid-name
     def test_argument_unnamed_unparented(self):
-        arg = ast.Argument(None, ast.Argument.DIRECTION_IN, 's')
+        signature = TypeParser('s').parse()
+        arg = ast.Argument(None, ast.Argument.DIRECTION_IN, signature)
         self.assertEqual(arg.format_name(), 'unnamed')
 
     def test_annotation_interface(self):
@@ -106,7 +113,8 @@ class TestAstNames(unittest.TestCase):
 
     def test_annotation_property(self):
         annotation = ast.Annotation('SomeAnnotation', 'value')
-        prop = ast.Property('AProperty', 's', ast.Property.ACCESS_READ, {
+        signature = TypeParser('s').parse()
+        prop = ast.Property('AProperty', signature, ast.Property.ACCESS_READ, {
             'SomeAnnotation': annotation,
         })
         iface = ast.Interface('SomeInterface', {}, {
@@ -139,7 +147,8 @@ class TestAstNames(unittest.TestCase):
 
     def test_annotation_argument(self):
         annotation = ast.Annotation('SomeAnnotation', 'value')
-        arg = ast.Argument('Argument', ast.Argument.DIRECTION_IN, 's', {
+        signature = TypeParser('s').parse()
+        arg = ast.Argument('Argument', ast.Argument.DIRECTION_IN, signature, {
             'SomeAnnotation': annotation,
         })
         method = ast.Method('AMethod', [arg])
@@ -162,7 +171,8 @@ class TestAstParenting(unittest.TestCase):
         annotation = ast.Annotation('SomeAnnotation', 'value')
         self.assertEqual(annotation.parent, None)
 
-        prop = ast.Property('AProperty', 's', ast.Property.ACCESS_READ, {
+        signature = TypeParser('s').parse()
+        prop = ast.Property('AProperty', signature, ast.Property.ACCESS_READ, {
             'SomeAnnotation': annotation,
         })
         self.assertEqual(prop.interface, None)
@@ -207,7 +217,8 @@ class TestAstParenting(unittest.TestCase):
         annotation = ast.Annotation('SomeAnnotation', 'value')
         self.assertEqual(annotation.parent, None)
 
-        arg = ast.Argument('SomeArgument', ast.Argument.DIRECTION_IN, 's', {
+        signature = TypeParser('s').parse()
+        arg = ast.Argument('SomeArgument', ast.Argument.DIRECTION_IN, signature, {
             'SomeAnnotation': annotation,
         })
         self.assertEqual(arg.parent, None)

--- a/dbusapi/tests/test_interfaceparser.py
+++ b/dbusapi/tests/test_interfaceparser.py
@@ -56,7 +56,7 @@ def _test_parser(xml):
     interfaces = root_node.interfaces if root_node else None
     os.unlink(tmpfile)
 
-    return (parser, interfaces, tmpfile)
+    return parser, interfaces, tmpfile
 
 
 # pylint: disable=too-many-public-methods
@@ -79,9 +79,9 @@ class TestParserErrors(unittest.TestCase):
 
     def test_nonabsolute_node_name(self):
         self.assertOutput(
-            "<node name='relative/N'></node>", [
+            "<node name='rel/N'></node>", [
                 ('node-naming',
-                 'Root node name is not an absolute object path ‘relative/N’.'),
+                 'Root node name is not an absolute object path ‘rel/N’.'),
             ])
 
     def test_missing_node_name(self):
@@ -93,9 +93,9 @@ class TestParserErrors(unittest.TestCase):
 
     def test_nonrelative_node_name(self):
         self.assertOutput(
-            "<node><node name='/absolute/N'/></node>", [
+            "<node><node name='/abs/N'/></node>", [
                 ('node-naming',
-                 'Non-root node name is not a relative object path ‘/absolute/N’.'),
+                 'Non-root node name is not a relative object path ‘/abs/N’.'),
             ])
 
     def test_duplicate_node(self):
@@ -379,34 +379,32 @@ class TestParserNormal(unittest.TestCase):
 
             http://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
         """
-        self.assertParse(
-            """
-            <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-             "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-            <node name="/com/example/sample_object">
-              <interface name="com.example.SampleInterface">
-                <method name="Frobate">
-                  <arg name="foo" type="i" direction="in"/>
-                  <arg name="bar" type="s" direction="out"/>
-                  <arg name="baz" type="a{us}" direction="out"/>
-                  <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
-                </method>
-                <method name="Bazify">
-                  <arg name="bar" type="(iiu)" direction="in"/>
-                  <arg name="bar" type="v" direction="out"/>
-                </method>
-                <method name="Mogrify">
-                  <arg name="bar" type="(iiav)" direction="in"/>
-                </method>
-                <signal name="Changed">
-                  <arg name="new_value" type="b"/>
-                </signal>
-                <property name="Bar" type="y" access="readwrite"/>
-              </interface>
-              <node name="child_of_sample_object"/>
-              <node name="another_child_of_sample_object"/>
-            </node>
-            """)
+        self.assertParse("""
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/com/example/sample_object">
+  <interface name="com.example.SampleInterface">
+    <method name="Frobate">
+      <arg name="foo" type="i" direction="in"/>
+      <arg name="bar" type="s" direction="out"/>
+      <arg name="baz" type="a{us}" direction="out"/>
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </method>
+    <method name="Bazify">
+      <arg name="bar" type="(iiu)" direction="in"/>
+      <arg name="bar" type="v" direction="out"/>
+    </method>
+    <method name="Mogrify">
+      <arg name="bar" type="(iiav)" direction="in"/>
+    </method>
+    <signal name="Changed">
+      <arg name="new_value" type="b"/>
+    </signal>
+    <property name="Bar" type="y" access="readwrite"/>
+  </interface>
+  <node name="child_of_sample_object"/>
+  <node name="another_child_of_sample_object"/>
+</node>""")
 
 
 class TestParserOutputCodes(unittest.TestCase):

--- a/dbusapi/tests/test_typeparser.py
+++ b/dbusapi/tests/test_typeparser.py
@@ -30,7 +30,6 @@ Unit tests for dbusapi.typeparser
 
 
 from dbusapi.typeparser import TypeParser
-from dbusapi import ast
 import unittest
 
 
@@ -57,61 +56,104 @@ class TestParserErrors(unittest.TestCase):
                 ('unknown-type', 'Unknown type ‘?’.'),
             ])
 
+    def test_incomplete(self):
+        self.assertOutput(
+            "aa", [
+                ('invalid-type', 'Incomplete array declaration.'),
+            ])
+
+    def test_incomplete2(self):
+        self.assertOutput(
+            "(ii", [
+                ('invalid-type', 'Incomplete structure declaration.'),
+            ])
+
+    def test_incomplete3(self):
+        self.assertOutput(
+            "ii)", [
+                ('unknown-type', 'Unknown type ‘)’.'),
+            ])
+
+    def test_incomplete4(self):
+        self.assertOutput(
+            "a{suu}", [
+                ('invalid-type', 'Invalid dictionary declaration.'),
+            ])
+
+    def test_incomplete5(self):
+        self.assertOutput(
+            "a{su", [
+                ('invalid-type', 'Incomplete dictionary declaration.'),
+            ])
+
+    def test_incomplete6(self):
+        self.assertOutput(
+            "a{s", [
+                ('invalid-type', 'Incomplete dictionary declaration.'),
+            ])
+
 
 class TestParserNormal(unittest.TestCase):
     """Test normal parsing of unusual input in the TypeParser."""
 
     # pylint: disable=invalid-name
-    def assertParse(self, signature, expected_names):  # noqa
-        (parser, types) = _test_parser(signature)
+    def assertParse(self, signature):  # noqa
+        (parser, type) = _test_parser(signature)
         self.assertEqual(parser.get_output(), [])
-        for (one_type, expected_name) in zip(types, expected_names):
-            self.assertEqual(one_type.format_name(), expected_name)
+        actual_signature = str(type)
+        self.assertEqual(signature, actual_signature)
 
     def test_int32(self):
-        self.assertParse(
-            "i",
-            ["INT32"])
+        self.assertParse("i")
 
     def test_two_int32(self):
-        self.assertParse(
-            "ii",
-            ["INT32", "INT32"])
+        self.assertParse("ii")
+
+    def test_two_int32_arrays(self):
+        self.assertParse("aiai")
 
     def test_uint32(self):
-        self.assertParse(
-            "u",
-            ["UINT32"])
+        self.assertParse("u")
+
+    def test_two_uint32(self):
+        self.assertParse("uu")
 
     def test_array_int32(self):
-        self.assertParse(
-            "ai",
-            ["ARRAY"])
+        self.assertParse("ai")
 
     def test_array_array_int32(self):
-        self.assertParse(
-            "aai",
-            ["ARRAY"])
+        self.assertParse("aai")
+
+    def test_array_uint32(self):
+        self.assertParse("au")
+
+    def test_array_variant(self):
+        self.assertParse("av")
 
     def test_struct_ints(self):
-        self.assertParse(
-            "(iii)",
-            ["STRUCT"])
+        self.assertParse("(iii)")
+
+    def test_two_structs(self):
+        self.assertParse("(ii)(ii)")
 
     def test_struct_struct_ints(self):
-        self.assertParse(
-            "(i(ii))",
-            ["STRUCT"])
+        self.assertParse("(i(ii))")
+
+    def test_struct_variant(self):
+        self.assertParse("(v)")
+
+    def test_struct_ius(self):
+        self.assertParse("(ius)")
 
     def test_array_struct_ints(self):
-        self.assertParse(
-            "a(ii)",
-            ["ARRAY"])
+        self.assertParse("a(ii)")
 
     def test_array_dict(self):
-        self.assertParse(
-            "a{us}",
-            ["ARRAY"])
+        self.assertParse("a{us}")
+
+    def test_array_dict2(self):
+        self.assertParse("a{us}i")
+
 
 if __name__ == '__main__':
     # Run test suite

--- a/dbusapi/tests/test_typeparser.py
+++ b/dbusapi/tests/test_typeparser.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4
+#
+# Copyright © 2015 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Unit tests for dbusapi.typeparser
+"""
+
+
+from dbusapi.typeparser import TypeParser
+from dbusapi import ast
+import unittest
+
+
+def _test_parser(signature):
+    """Build a TypeParser for a signature and parse it."""
+    parser = TypeParser(signature)
+    types = parser.parse()
+    return parser, types
+
+
+class TestParserErrors(unittest.TestCase):
+    """Test error handling in the TypeParser."""
+
+    # pylint: disable=invalid-name
+    def assertOutput(self, signature, partial_output):  # noqa
+        (parser, types) = _test_parser(signature)
+        self.assertEqual(types, None)
+        actual_output = [(i[0], i[1]) for i in partial_output]
+        self.assertEqual(parser.get_output(), actual_output)
+
+    def test_unknown_type(self):
+        self.assertOutput(
+            "?", [
+                ('unknown-type', 'Unknown type ‘?’.'),
+            ])
+
+
+class TestParserNormal(unittest.TestCase):
+    """Test normal parsing of unusual input in the TypeParser."""
+
+    # pylint: disable=invalid-name
+    def assertParse(self, signature, expected_names):  # noqa
+        (parser, types) = _test_parser(signature)
+        self.assertEqual(parser.get_output(), [])
+        for (one_type, expected_name) in zip(types, expected_names):
+            self.assertEqual(one_type.format_name(), expected_name)
+
+    def test_int32(self):
+        self.assertParse(
+            "i",
+            ["INT32"])
+
+    def test_two_int32(self):
+        self.assertParse(
+            "ii",
+            ["INT32", "INT32"])
+
+    def test_uint32(self):
+        self.assertParse(
+            "u",
+            ["UINT32"])
+
+    def test_array_int32(self):
+        self.assertParse(
+            "ai",
+            ["ARRAY"])
+
+    def test_array_array_int32(self):
+        self.assertParse(
+            "aai",
+            ["ARRAY"])
+
+    def test_struct_ints(self):
+        self.assertParse(
+            "(iii)",
+            ["STRUCT"])
+
+    def test_struct_struct_ints(self):
+        self.assertParse(
+            "(i(ii))",
+            ["STRUCT"])
+
+    def test_array_struct_ints(self):
+        self.assertParse(
+            "a(ii)",
+            ["ARRAY"])
+
+    def test_array_dict(self):
+        self.assertParse(
+            "a{us}",
+            ["ARRAY"])
+
+if __name__ == '__main__':
+    # Run test suite
+    unittest.main()

--- a/dbusapi/tests/test_typeparser.py
+++ b/dbusapi/tests/test_typeparser.py
@@ -98,9 +98,9 @@ class TestParserNormal(unittest.TestCase):
 
     # pylint: disable=invalid-name
     def assertParse(self, signature):  # noqa
-        (parser, type) = _test_parser(signature)
+        (parser, type_signature) = _test_parser(signature)
         self.assertEqual(parser.get_output(), [])
-        actual_signature = str(type)
+        actual_signature = str(type_signature)
         self.assertEqual(signature, actual_signature)
 
     def test_int32(self):

--- a/dbusapi/typeparser.py
+++ b/dbusapi/typeparser.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4
+#
+# Copyright © 2015 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from dbusapi import ast
+
+
+class TypeParser(object):
+
+    """
+    Parse a D-Bus type string.
+
+    This validates the string, but not exceedingly strictly..
+    """
+
+    def __init__(self, signature):
+        """
+        Construct a new TypeParser.
+
+        Args:
+            signature: A D-Bus type string.
+        """
+        self.signature = signature
+        self._output = []
+        self._index = 0
+
+    @staticmethod
+    def get_output_codes():
+        """Return a list of all possible output codes."""
+        # FIXME: Hard-coded for the moment.
+        return [
+            'unknown-type',
+        ]
+
+    def _issue_output(self, code, message):
+        """Append a message to the parser output."""
+        self._output.append((code, message))
+
+    def get_output(self):
+        """Return a list of all logged parser messages."""
+        return self._output
+
+    def _get_next_character(self):
+        """Return the next character from the signature."""
+        if self._index < len(self.signature):
+            character = self.signature[self._index]
+            self._index += 1
+        else:
+            character = None
+        return character
+
+    def _parse_one(self, character):
+        """Parse one character of a signature."""
+        if character == "y":
+            return ast.Byte()
+        elif character == "b":
+            return ast.Boolean()
+        elif character == "n":
+            return ast.Int16()
+        elif character == "q":
+            return ast.UInt16()
+        elif character == "i":
+            return ast.Int32()
+        elif character == "u":
+            return ast.UInt32()
+        elif character == "x":
+            return ast.Int64()
+        elif character == "t":
+            return ast.UInt64()
+        elif character == "d":
+            return ast.Double()
+        elif character == "s":
+            return ast.String()
+        elif character == "o":
+            return ast.ObjectPath()
+        elif character == "g":
+            return ast.Signature()
+        elif character == "v":
+            return ast.Variant()
+        elif character == "h":
+            return ast.UnixFD()
+        elif character == "a":
+            res = ast.Array()
+            character = self._get_next_character()
+            if not character:
+                return None
+            one_type = self._parse_one(character)
+            if not one_type:
+                self._issue_output('unknown-type',
+                                   'Unknown type ‘%s’.' % character)
+            res.members.append(one_type)
+            return res
+        elif character == "(":
+            res = ast.Struct()
+            while True:
+                character = self._get_next_character()
+                if not character:
+                    return None
+                if character == ")":
+                    break
+                one_type = self._parse_one(character)
+                if not one_type:
+                    self._issue_output('unknown-type',
+                                       'Unknown type ‘%s’.' % character)
+                res.members.append(one_type)
+            return res
+        elif character == "{":
+            res = ast.DictEntry()
+            while True:
+                character = self._get_next_character()
+                if not character:
+                    return None
+                if character == "}":
+                    break
+                one_type = self._parse_one(character)
+                if not one_type:
+                    self._issue_output('unknown-type',
+                                       'Unknown type ‘%s’.' % character)
+                res.members.append(one_type)
+            return res
+        else:
+            return None
+
+    def parse(self):
+        """
+        Parse the type string and build an AST.
+
+        Returns:
+            A non-empty list of types.
+
+            If parsing fails, None is returned.
+        """
+        self._output = []
+        self._index = 0
+
+        out = []
+        while True:
+            character = self._get_next_character()
+            if not character:
+                break
+
+            one_type = self._parse_one(character)
+            if not one_type:
+                self._issue_output('unknown-type',
+                                   'Unknown type ‘%s’.' % character)
+            out.append(one_type)
+
+        # Squash output on error.
+        if self._output:
+            return None
+
+        return out

--- a/dbusapi/typeparser.py
+++ b/dbusapi/typeparser.py
@@ -167,7 +167,7 @@ class TypeParser(object):
         self._output = []
         self._index = 0
 
-        out = ast.Signature()
+        out = ast.TypeSignature()
         while True:
             character = self._get_next_character()
             if not character:

--- a/dbusdeviation/tests/test_interfacecomparator.py
+++ b/dbusdeviation/tests/test_interfacecomparator.py
@@ -61,8 +61,10 @@ class TestComparatorErrors(unittest.TestCase):
         old_parser = InterfaceParser(old_tmpfile)
         new_parser = InterfaceParser(new_tmpfile)
 
-        old_interfaces = old_parser.parse()
-        new_interfaces = new_parser.parse()
+        old_root_node = old_parser.parse()
+        old_interfaces = old_root_node.interfaces
+        new_root_node = new_parser.parse()
+        new_interfaces = new_root_node.interfaces
 
         os.unlink(new_tmpfile)
         os.unlink(old_tmpfile)

--- a/dbusdeviation/utilities/diff.py
+++ b/dbusdeviation/utilities/diff.py
@@ -64,7 +64,8 @@ def _parse_file(filename, parser):
     list. Print an error and exit if parsing fails.
     """
     try:
-        interfaces = parser.parse()
+        root_node = parser.parse()
+        interfaces = root_node.interfaces
 
         # Handle parse errors.
         if interfaces is None:

--- a/dbusdeviation/utilities/vcs_helper.py
+++ b/dbusdeviation/utilities/vcs_helper.py
@@ -59,7 +59,7 @@ def named_pipe():
         os.mkfifo(path)
         yield path
     finally:
-        shutil.rmtree(dirname)
+        shutil.rmtree(dirname),
 
 
 def _git_command(args, command):


### PR DESCRIPTION
I added D-Bus type/signature AST representation and a new parser for it.

I also added support for the < node > element. The introspection example from the D-Bus specification can be successfully parsed now.

Fixed PEP8 and pylint errors from the previous request.