### PR TITLE
Added support for the <node> element and interface and member name validation.

### DIFF
--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -32,12 +32,52 @@ TODO
 # pylint: disable=too-few-public-methods
 
 
+class Node(object):
+
+    """
+    AST representation of a <node> element.
+
+    This represents the top level of a D-Bus API.
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name=None, interfaces=None, nodes=None):
+        """
+        Construct a new ast.Node.
+
+        Args:
+            name: node name; a non-empty string
+            interfaces: potentially empty dict of interfaces in the node
+                containing ast.Interface instances
+            nodes: potentially empty dict of sub-nodes in the node
+                containing ast.Node instances
+        """
+        if interfaces is None:
+            interfaces = {}
+        if nodes is None:
+            nodes = {}
+
+        self.parent_node = None
+        self.name = name
+        self.interfaces = interfaces
+        self.nodes = nodes
+
+        for interface in self.interfaces.values():
+            interface.parent_node = self
+        for node in self.nodes.values():
+            node.parent_node = self
+
+    def format_name(self):
+        u"""Format the node’s name as a human-readable string."""
+        return self.name
+
+
 class Interface(object):
 
     """
     AST representation of an <interface> element.
 
-    This represents the top level of a D-Bus API.
+    This represents the most common node member of a D-Bus API.
     """
 
     # pylint: disable=too-many-arguments
@@ -67,6 +107,7 @@ class Interface(object):
         if annotations is None:
             annotations = {}
 
+        self.parent_node = None
         self.name = name
         self.methods = methods
         self.properties = properties

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -32,7 +32,6 @@ TODO
 # pylint: disable=too-few-public-methods
 
 
-# pylint: disable=interface-not-implemented
 class Interface(object):
 
     """

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -31,7 +31,6 @@ TODO
 import os
 
 # PyPy support
-# pylint: disable=interface-not-implemented
 try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
@@ -51,7 +50,6 @@ def _ignore_node(node):
     return node.tag[0] == '{'  # in a namespace
 
 
-# pylint: disable=interface-not-implemented
 class InterfaceParser(object):
 
     """

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -29,6 +29,7 @@ TODO
 """
 
 import os
+import re
 
 # PyPy support
 try:
@@ -80,6 +81,8 @@ class InterfaceParser(object):
         # FIXME: Hard-coded for the moment.
         return [
             'unknown-node',
+            'node-naming',
+            'duplicate-node',
             'duplicate-interface',
             'missing-attribute',
             'duplicate-method',
@@ -94,6 +97,16 @@ class InterfaceParser(object):
     def get_output(self):
         """Return a list of all logged parser messages."""
         return self._output
+
+    @staticmethod
+    def is_valid_absolute_object_path(path):
+        """Validate an absolute D-Bus object path."""
+        return re.match(r'(/[A-Za-z0-9_]+)+', path) is not None
+
+    @staticmethod
+    def is_valid_relative_object_path(path):
+        """Validate a relative D-Bus object path."""
+        return re.match(r'[A-Za-z0-9_]+(/[A-Za-z0-9_]+)*', path) is not None
 
     def parse(self):
         """
@@ -125,14 +138,35 @@ class InterfaceParser(object):
                     break
 
         # Continue parsing as per the D-Bus introspection format
-        interfaces = {}
 
         if root.tag != 'node':
             self._issue_output('unknown-node',
                                'Unknown root node ‘%s’.' % root.tag)
-            return interfaces
+            return None
 
-        for node in root.getchildren():
+        root_node = self._parse_node(root)
+
+        if root_node.name and \
+           not self.is_valid_absolute_object_path(root_node.name):
+            self._issue_output('node-naming',
+                               'Root node name is not an absolute object path '
+                               '‘%s’.' % root_node.name)
+            return None
+
+        return root_node
+
+    def _parse_node(self, node_node):
+        """Parse a <node> element; return an ast.Node or None."""
+        assert node_node.tag == 'node'
+
+        if 'name' in node_node.attrib:
+            name = node_node.attrib['name']
+        else:
+            name = None
+        nodes = {}
+        interfaces = {}
+
+        for node in node_node.getchildren():
             if node.tag == 'interface':
                 interface = self._parse_interface(node)
                 if interface is None:
@@ -145,6 +179,30 @@ class InterfaceParser(object):
                     continue
 
                 interfaces[interface.name] = interface
+            elif node.tag == 'node':
+                sub_node = self._parse_node(node)
+                if sub_node is None:
+                    continue
+
+                if not sub_node.name:
+                    self._issue_output('missing-attribute',
+                                       'Missing required attribute ‘name’ '
+                                       'in non-root node.')
+                    continue
+
+                if not self.is_valid_relative_object_path(sub_node.name[0]):
+                    self._issue_output('node-naming',
+                                       'Non-root node name is not a relative '
+                                       'object path ‘%s’.' % sub_node.name)
+                    continue
+
+                if sub_node.name in nodes:
+                    self._issue_output('duplicate-node',
+                                       'Duplicate node definition ‘%s’.' %
+                                       sub_node.format_name())
+                    continue
+
+                nodes[sub_node.name] = sub_node
             elif _ignore_node(node):
                 pass
             else:
@@ -152,7 +210,7 @@ class InterfaceParser(object):
                                    'Unknown node ‘%s’ in root.' %
                                    node.tag)
 
-        return interfaces
+        return ast.Node(name, interfaces, nodes)
 
     # pylint: disable=too-many-branches
     def _parse_interface(self, interface_node):  # noqa

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -52,7 +52,6 @@ def _ignore_node(node):
 
 
 class InterfaceParser(object):
-
     """
     Parse a D-Bus introspection XML file.
 
@@ -83,6 +82,7 @@ class InterfaceParser(object):
             'unknown-node',
             'node-naming',
             'duplicate-node',
+            'interface-naming',
             'duplicate-interface',
             'missing-attribute',
             'duplicate-method',
@@ -107,6 +107,13 @@ class InterfaceParser(object):
     def is_valid_relative_object_path(path):
         """Validate a relative D-Bus object path."""
         return re.match(r'[A-Za-z0-9_]+(/[A-Za-z0-9_]+)*', path) is not None
+
+    @staticmethod
+    def is_valid_interface_name(name):
+        """Validate a D-Bus interface name."""
+        return len(name) <= 255 and \
+            re.match(r'[A-Za-z_][A-Za-z0-9_]*'
+                     '(\.[A-Za-z_][A-Za-z0-9_]*)+', name) is not None
 
     def parse(self):
         """
@@ -147,7 +154,7 @@ class InterfaceParser(object):
         root_node = self._parse_node(root)
 
         if root_node.name and \
-           not self.is_valid_absolute_object_path(root_node.name):
+                not self.is_valid_absolute_object_path(root_node.name):
             self._issue_output('node-naming',
                                'Root node name is not an absolute object path '
                                '‘%s’.' % root_node.name)
@@ -221,6 +228,12 @@ class InterfaceParser(object):
             self._issue_output('missing-attribute',
                                'Missing required attribute ‘%s’ in '
                                'interface.' % 'name')
+            return None
+
+        if not self.is_valid_interface_name(interface_node.attrib['name']):
+            self._issue_output('interface-naming',
+                               'Invalid interface name ‘%s’.' %
+                               interface_node.attrib['name'])
             return None
 
         name = interface_node.attrib['name']

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -112,7 +112,7 @@ class InterfaceParser(object):
         out = self._parse_root(tree.getroot())
 
         # Squash output on error.
-        if len(self._output) != 0:
+        if self._output:
             return None
 
         return out

--- a/dbusapi/tests/test_interfaceparser.py
+++ b/dbusapi/tests/test_interfaceparser.py
@@ -112,11 +112,18 @@ class TestParserErrors(unittest.TestCase):
                  'Duplicate node definition ‘N’.'),
             ])
 
+    def test_invalid_interface_name(self):
+        self.assertOutput(
+            "<node><interface name='0'/></node>", [
+                ('interface-naming',
+                 'Invalid interface name ‘0’.'),
+            ])
+
     def test_duplicate_interface(self):
         self.assertOutput(
-            "<node><interface name='I'/><interface name='I'/></node>", [
+            "<node><interface name='I.I'/><interface name='I.I'/></node>", [
                 ('duplicate-interface',
-                 'Duplicate interface definition ‘I’.'),
+                 'Duplicate interface definition ‘I.I’.'),
             ])
 
     def test_unknown_interface_node(self):
@@ -134,71 +141,71 @@ class TestParserErrors(unittest.TestCase):
 
     def test_duplicate_method(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<method name='M'/><method name='M'/>"
             "</interface></node>", [
                 ('duplicate-method',
-                 'Duplicate method definition ‘I.M’.'),
+                 'Duplicate method definition ‘I.I.M’.'),
             ])
 
     def test_duplicate_signal(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<signal name='S'/><signal name='S'/>"
             "</interface></node>", [
                 ('duplicate-signal',
-                 'Duplicate signal definition ‘I.S’.'),
+                 'Duplicate signal definition ‘I.I.S’.'),
             ])
 
     def test_duplicate_property(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<property name='P' type='s' access='readwrite'/>"
             "<property name='P' type='s' access='readwrite'/>"
             "</interface></node>", [
                 ('duplicate-property',
-                 'Duplicate property definition ‘I.P’.'),
+                 'Duplicate property definition ‘I.I.P’.'),
             ])
 
     def test_unknown_sub_interface_node(self):
         self.assertOutput(
-            "<node><interface name='I'><badnode/></interface></node>", [
-                ('unknown-node', 'Unknown node ‘badnode’ in interface ‘I’.'),
+            "<node><interface name='I.I'><badnode/></interface></node>", [
+                ('unknown-node', 'Unknown node ‘badnode’ in interface ‘I.I’.'),
             ])
 
     def test_method_missing_name(self):
         self.assertOutput(
-            "<node><interface name='I'><method/></interface></node>", [
+            "<node><interface name='I.I'><method/></interface></node>", [
                 ('missing-attribute',
                  'Missing required attribute ‘name’ in method.'),
             ])
 
     def test_unknown_method_node(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<method name='M'><badnode/></method>"
             "</interface></node>", [
-                ('unknown-node', 'Unknown node ‘badnode’ in method ‘I.M’.'),
+                ('unknown-node', 'Unknown node ‘badnode’ in method ‘I.I.M’.'),
             ])
 
     def test_signal_missing_name(self):
         self.assertOutput(
-            "<node><interface name='I'><signal/></interface></node>", [
+            "<node><interface name='I.I'><signal/></interface></node>", [
                 ('missing-attribute',
                  'Missing required attribute ‘name’ in signal.'),
             ])
 
     def test_unknown_signal_node(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<signal name='S'><badnode/></signal>"
             "</interface></node>", [
-                ('unknown-node', 'Unknown node ‘badnode’ in signal ‘I.S’.'),
+                ('unknown-node', 'Unknown node ‘badnode’ in signal ‘I.I.S’.'),
             ])
 
     def test_property_missing_name(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<property type='s' access='readwrite'/>"
             "</interface></node>", [
                 ('missing-attribute',
@@ -207,7 +214,7 @@ class TestParserErrors(unittest.TestCase):
 
     def test_property_missing_type(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<property name='P' access='readwrite'/>"
             "</interface></node>", [
                 ('missing-attribute',
@@ -216,7 +223,7 @@ class TestParserErrors(unittest.TestCase):
 
     def test_property_missing_access(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<property name='P' type='s'/>"
             "</interface></node>", [
                 ('missing-attribute',
@@ -225,26 +232,26 @@ class TestParserErrors(unittest.TestCase):
 
     def test_unknown_property_node(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<property name='P' type='s' access='readwrite'>"
             "<badnode/>"
             "</property>"
             "</interface></node>", [
-                ('unknown-node', 'Unknown node ‘badnode’ in property ‘I.P’.'),
+                ('unknown-node', 'Unknown node ‘badnode’ in property ‘I.I.P’.'),
             ])
 
     def test_unknown_arg_node(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<method name='M'><arg type='s'><badnode/></arg></method>"
             "</interface></node>", [
                 ('unknown-node',
-                 'Unknown node ‘badnode’ in arg ‘unnamed’ of ‘I.M’.'),
+                 'Unknown node ‘badnode’ in arg ‘unnamed’ of ‘I.I.M’.'),
             ])
 
     def test_arg_missing_type(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<method name='M'><arg/></method>"
             "</interface></node>", [
                 ('missing-attribute',
@@ -253,7 +260,7 @@ class TestParserErrors(unittest.TestCase):
 
     def test_annotation_missing_name(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<annotation value='V'/>"
             "</interface></node>", [
                 ('missing-attribute',
@@ -262,7 +269,7 @@ class TestParserErrors(unittest.TestCase):
 
     def test_annotation_missing_value(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<annotation name='N'/>"
             "</interface></node>", [
                 ('missing-attribute',
@@ -271,11 +278,11 @@ class TestParserErrors(unittest.TestCase):
 
     def test_unknown_annotation_node(self):
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<annotation name='N' value='V'><badnode/></annotation>"
             "</interface></node>", [
                 ('unknown-node',
-                 'Unknown node ‘badnode’ in annotation ‘I.N’.'),
+                 'Unknown node ‘badnode’ in annotation ‘I.I.N’.'),
             ])
 
 
@@ -294,7 +301,7 @@ class TestParserNormal(unittest.TestCase):
         self.assertParse(
             "<tp:spec xmlns:tp='"
             "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
-            "'><node><interface name='I'/></node></tp:spec>")
+            "'><node><interface name='I.I'/></node></tp:spec>")
 
     def test_doc_root(self):
         """Test that doc tags are ignored in the root."""
@@ -315,7 +322,7 @@ class TestParserNormal(unittest.TestCase):
             "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
             "' xmlns:doc='"
             "http://www.freedesktop.org/dbus/1.0/doc.dtd"
-            "'><interface name='I'>"
+            "'><interface name='I.I'>"
             "<tp:docstring>Ignore me.</tp:docstring>"
             "<doc:doc>Ignore me.</doc:doc>"
             "</interface></node>")
@@ -327,7 +334,7 @@ class TestParserNormal(unittest.TestCase):
             "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
             "' xmlns:doc='"
             "http://www.freedesktop.org/dbus/1.0/doc.dtd"
-            "'><interface name='I'><method name='M'>"
+            "'><interface name='I.I'><method name='M'>"
             "<tp:docstring>Ignore me.</tp:docstring>"
             "<doc:doc>Ignore me.</doc:doc>"
             "</method></interface></node>")
@@ -339,7 +346,7 @@ class TestParserNormal(unittest.TestCase):
             "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
             "' xmlns:doc='"
             "http://www.freedesktop.org/dbus/1.0/doc.dtd"
-            "'><interface name='I'><signal name='S'>"
+            "'><interface name='I.I'><signal name='S'>"
             "<tp:docstring>Ignore me.</tp:docstring>"
             "<doc:doc>Ignore me.</doc:doc>"
             "</signal></interface></node>")
@@ -351,7 +358,7 @@ class TestParserNormal(unittest.TestCase):
             "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
             "' xmlns:doc='"
             "http://www.freedesktop.org/dbus/1.0/doc.dtd"
-            "'><interface name='I'><property name='P' type='s' access='read'>"
+            "'><interface name='I.I'><property name='P' type='s' access='read'>"
             "<tp:docstring>Ignore me.</tp:docstring>"
             "<doc:doc>Ignore me.</doc:doc>"
             "</property></interface></node>")
@@ -363,7 +370,7 @@ class TestParserNormal(unittest.TestCase):
             "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
             "' xmlns:doc='"
             "http://www.freedesktop.org/dbus/1.0/doc.dtd"
-            "'><interface name='I'><method name='M'><arg type='s'>"
+            "'><interface name='I.I'><method name='M'><arg type='s'>"
             "<tp:docstring>Ignore me.</tp:docstring>"
             "<doc:doc>Ignore me.</doc:doc>"
             "</arg></method></interface></node>")
@@ -375,7 +382,7 @@ class TestParserNormal(unittest.TestCase):
             "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
             "' xmlns:doc='"
             "http://www.freedesktop.org/dbus/1.0/doc.dtd"
-            "'><interface name='I'><annotation name='A' value='V'>"
+            "'><interface name='I.I'><annotation name='A' value='V'>"
             "<tp:docstring>Ignore me.</tp:docstring>"
             "<doc:doc>Ignore me.</doc:doc>"
             "</annotation></interface></node>")
@@ -445,7 +452,7 @@ class TestParserRecovery(unittest.TestCase):
     def test_annotation_interface(self):
         """Test recovery from invalid annotations in an interface."""
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<annotation/><method/>"
             "</interface></node>", [
                 ('missing-attribute',
@@ -457,7 +464,7 @@ class TestParserRecovery(unittest.TestCase):
     def test_annotation_method(self):
         """Test recovery from invalid annotations in a method."""
         self.assertOutput(
-            "<node><interface name='I'><method name='M'>"
+            "<node><interface name='I.I'><method name='M'>"
             "<annotation/><arg/>"
             "</method></interface></node>", [
                 ('missing-attribute',
@@ -469,7 +476,7 @@ class TestParserRecovery(unittest.TestCase):
     def test_annotation_signal(self):
         """Test recovery from invalid annotations in a signal."""
         self.assertOutput(
-            "<node><interface name='I'><signal name='S'>"
+            "<node><interface name='I.I'><signal name='S'>"
             "<annotation/><arg/>"
             "</signal></interface></node>", [
                 ('missing-attribute',
@@ -481,7 +488,7 @@ class TestParserRecovery(unittest.TestCase):
     def test_annotation_property(self):
         """Test recovery from invalid annotations in a property."""
         self.assertOutput(
-            "<node><interface name='I'>"
+            "<node><interface name='I.I'>"
             "<property name='P' type='s' access='read'>"
             "<annotation/><badnode/>"
             "</property>"
@@ -489,19 +496,19 @@ class TestParserRecovery(unittest.TestCase):
                 ('missing-attribute',
                  'Missing required attribute ‘name’ in annotation.'),
                 ('unknown-node',
-                 'Unknown node ‘badnode’ in property ‘I.P’.'),
+                 'Unknown node ‘badnode’ in property ‘I.I.P’.'),
             ])
 
     def test_annotation_arg(self):
         """Test recovery from invalid annotations in an arg."""
         self.assertOutput(
-            "<node><interface name='I'><method name='M'><arg type='s'>"
+            "<node><interface name='I.I'><method name='M'><arg type='s'>"
             "<annotation/><badnode/>"
             "</arg></method></interface></node>", [
                 ('missing-attribute',
                  'Missing required attribute ‘name’ in annotation.'),
                 ('unknown-node',
-                 'Unknown node ‘badnode’ in arg ‘unnamed’ of ‘I.M’.'),
+                 'Unknown node ‘badnode’ in arg ‘unnamed’ of ‘I.I.M’.'),
             ])
 
 

--- a/dbusapi/tests/test_interfaceparser.py
+++ b/dbusapi/tests/test_interfaceparser.py
@@ -52,7 +52,8 @@ def _test_parser(xml):
     """Build an InterfaceParser for the XML snippet and parse it."""
     tmpfile = _create_temp_xml_file(xml)
     parser = InterfaceParser(tmpfile)
-    interfaces = parser.parse()
+    root_node = parser.parse()
+    interfaces = root_node.interfaces if root_node else None
     os.unlink(tmpfile)
 
     return parser, interfaces, tmpfile
@@ -74,6 +75,41 @@ class TestParserErrors(unittest.TestCase):
         self.assertOutput(
             "<notnode><irrelevant/></notnode>", [
                 ('unknown-node', 'Unknown root node ‘notnode’.'),
+            ])
+
+    def test_nonabsolute_node_name(self):
+        self.assertOutput(
+            "<node name='rel/N'></node>", [
+                ('node-naming',
+                 'Root node name is not an absolute object path ‘rel/N’.'),
+            ])
+
+    def test_invalid_node_name(self):
+        self.assertOutput(
+            "<node name='//'></node>", [
+                ('node-naming',
+                 'Root node name is not an absolute object path ‘//’.'),
+            ])
+
+    def test_missing_node_name(self):
+        self.assertOutput(
+            "<node><node /></node>", [
+                ('missing-attribute',
+                 'Missing required attribute ‘name’ in non-root node.'),
+            ])
+
+    def test_nonrelative_node_name(self):
+        self.assertOutput(
+            "<node><node name='/abs/N'/></node>", [
+                ('node-naming',
+                 'Non-root node name is not a relative object path ‘/abs/N’.'),
+            ])
+
+    def test_duplicate_node(self):
+        self.assertOutput(
+            "<node><node name='N'/><node name='N'/></node>", [
+                ('duplicate-node',
+                 'Duplicate node definition ‘N’.'),
             ])
 
     def test_duplicate_interface(self):
@@ -343,6 +379,39 @@ class TestParserNormal(unittest.TestCase):
             "<tp:docstring>Ignore me.</tp:docstring>"
             "<doc:doc>Ignore me.</doc:doc>"
             "</annotation></interface></node>")
+
+    def test_dbus_spec_example(self):
+        """
+        Test parsing the example from the D-Bus Specification:
+
+            http://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
+        """
+        self.assertParse("""
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/com/example/sample_object">
+  <interface name="com.example.SampleInterface">
+    <method name="Frobate">
+      <arg name="foo" type="i" direction="in"/>
+      <arg name="bar" type="s" direction="out"/>
+      <arg name="baz" type="a{us}" direction="out"/>
+      <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
+    </method>
+    <method name="Bazify">
+      <arg name="bar" type="(iiu)" direction="in"/>
+      <arg name="bar" type="v" direction="out"/>
+    </method>
+    <method name="Mogrify">
+      <arg name="bar" type="(iiav)" direction="in"/>
+    </method>
+    <signal name="Changed">
+      <arg name="new_value" type="b"/>
+    </signal>
+    <property name="Bar" type="y" access="readwrite"/>
+  </interface>
+  <node name="child_of_sample_object"/>
+  <node name="another_child_of_sample_object"/>
+</node>""")
 
 
 class TestParserOutputCodes(unittest.TestCase):

--- a/dbusapi/tests/test_interfaceparser.py
+++ b/dbusapi/tests/test_interfaceparser.py
@@ -55,7 +55,7 @@ def _test_parser(xml):
     interfaces = parser.parse()
     os.unlink(tmpfile)
 
-    return (parser, interfaces, tmpfile)
+    return parser, interfaces, tmpfile
 
 
 # pylint: disable=too-many-public-methods

--- a/dbusapi/tests/test_interfaceparser.py
+++ b/dbusapi/tests/test_interfaceparser.py
@@ -139,6 +139,15 @@ class TestParserErrors(unittest.TestCase):
                  'Missing required attribute ‘name’ in interface.'),
             ])
 
+    def test_invalid_method(self):
+        self.assertOutput(
+            "<node><interface name='I.I'>"
+            "<method name='0M'/>"
+            "</interface></node>", [
+                ('member-naming',
+                 'Invalid method name ‘I.I.0M’.'),
+            ])
+
     def test_duplicate_method(self):
         self.assertOutput(
             "<node><interface name='I.I'>"
@@ -146,6 +155,15 @@ class TestParserErrors(unittest.TestCase):
             "</interface></node>", [
                 ('duplicate-method',
                  'Duplicate method definition ‘I.I.M’.'),
+            ])
+
+    def test_invalid_signal(self):
+        self.assertOutput(
+            "<node><interface name='I.I'>"
+            "<signal name='*S'/>"
+            "</interface></node>", [
+                ('member-naming',
+                 'Invalid signal name ‘I.I.*S’.'),
             ])
 
     def test_duplicate_signal(self):

--- a/dbusdeviation/tests/test_interfacecomparator.py
+++ b/dbusdeviation/tests/test_interfacecomparator.py
@@ -61,8 +61,10 @@ class TestComparatorErrors(unittest.TestCase):
         old_parser = InterfaceParser(old_tmpfile)
         new_parser = InterfaceParser(new_tmpfile)
 
-        old_interfaces = old_parser.parse()
-        new_interfaces = new_parser.parse()
+        old_root_node = old_parser.parse()
+        old_interfaces = old_root_node.interfaces
+        new_root_node = new_parser.parse()
+        new_interfaces = new_root_node.interfaces
 
         os.unlink(new_tmpfile)
         os.unlink(old_tmpfile)

--- a/dbusdeviation/tests/test_interfacecomparator.py
+++ b/dbusdeviation/tests/test_interfacecomparator.py
@@ -85,363 +85,365 @@ class TestComparatorErrors(unittest.TestCase):
 
     def test_interface_removed(self):
         self.assertOutput(
-            "<node><interface name='A'/></node>",
+            "<node><interface name='I.A'/></node>",
             "<node></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'interface-removed',
-                 'Interface ‘A’ has been removed.'),
+                 'Interface ‘I.A’ has been removed.'),
             ])
 
     def test_interface_added(self):
         self.assertOutput(
             "<node></node>",
-            "<node><interface name='A'/></node>", [
+            "<node><interface name='I.A'/></node>", [
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'interface-added',
-                 'Interface ‘A’ has been added.'),
+                 'Interface ‘I.A’ has been added.'),
             ])
 
     def test_interface_deprecated(self):
         self.assertOutput(
-            "<node><interface name='A'/></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'/></node>",
+            "<node><interface name='I.A'>"
             "<annotation name='org.freedesktop.DBus.Deprecated' value='true'/>"
             "</interface></node>", [
                 (None, InterfaceComparator.OUTPUT_INFO,
                  'deprecated',
-                 'Node ‘A’ has been deprecated.'),
+                 'Node ‘I.A’ has been deprecated.'),
             ])
 
     def test_interface_deprecated_explicit(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<annotation name='org.freedesktop.DBus.Deprecated' "
             "value='false'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<annotation name='org.freedesktop.DBus.Deprecated' value='true'/>"
             "</interface></node>", [
                 (None, InterfaceComparator.OUTPUT_INFO,
                  'deprecated',
-                 'Node ‘A’ has been deprecated.'),
+                 'Node ‘I.A’ has been deprecated.'),
             ])
 
     def test_interface_undeprecated(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<annotation name='org.freedesktop.DBus.Deprecated' value='true'/>"
             "</interface></node>",
-            "<node><interface name='A'/></node>", [
+            "<node><interface name='I.A'/></node>", [
                 (None, InterfaceComparator.OUTPUT_INFO,
                  'undeprecated',
-                 'Node ‘A’ has been un-deprecated.'),
+                 'Node ‘I.A’ has been un-deprecated.'),
             ])
 
     def test_interface_undeprecated_explicit(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<annotation name='org.freedesktop.DBus.Deprecated' value='true'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<annotation name='org.freedesktop.DBus.Deprecated' "
             "value='false'/>"
             "</interface></node>", [
                 (None, InterfaceComparator.OUTPUT_INFO,
                  'undeprecated',
-                 'Node ‘A’ has been un-deprecated.'),
+                 'Node ‘I.A’ has been un-deprecated.'),
             ])
 
     def test_interface_name_changed(self):
         self.assertOutput(
-            "<node><interface name='A'/></node>",
-            "<node><interface name='A2'/></node>", [
+            "<node><interface name='I.A'/></node>",
+            "<node><interface name='I.A2'/></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'interface-removed',
-                 'Interface ‘A’ has been removed.'),
+                 'Interface ‘I.A’ has been removed.'),
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'interface-added',
-                 'Interface ‘A2’ has been added.')
+                 'Interface ‘I.A2’ has been added.')
             ])
 
     def test_method_removed(self):
         self.assertOutput(
-            "<node><interface name='A'><method name='M'/></interface></node>",
-            "<node><interface name='A'/></node>", [
+            "<node><interface name='I.A'><method name='M'/></interface></node>",
+            "<node><interface name='I.A'/></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'method-removed',
-                 'Method ‘A.M’ has been removed.'),
+                 'Method ‘I.A.M’ has been removed.'),
             ])
 
     def test_method_added(self):
         self.assertOutput(
-            "<node><interface name='A'/></node>",
-            "<node><interface name='A'><method name='M'/></interface></node>",
+            "<node><interface name='I.A'/></node>",
+            "<node><interface name='I.A'><method name='M'/></interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'method-added',
-                 'Method ‘A.M’ has been added.'),
+                 'Method ‘I.A.M’ has been added.'),
             ])
 
     def test_method_name_changed(self):
         self.assertOutput(
-            "<node><interface name='A'><method name='M'/></interface></node>",
-            "<node><interface name='A'><method name='M2'/></interface></node>",
+            "<node><interface name='I.A'>"
+            "<method name='M'/></interface></node>",
+            "<node><interface name='I.A'>"
+            "<method name='M2'/></interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'method-removed',
-                 'Method ‘A.M’ has been removed.'),
+                 'Method ‘I.A.M’ has been removed.'),
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'method-added',
-                 'Method ‘A.M2’ has been added.'),
+                 'Method ‘I.A.M2’ has been added.'),
             ])
 
     def test_method_arg_removed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='s' direction='in'/></method>"
             "</interface></node>",
-            "<node><interface name='A'><method name='M'/></interface></node>",
+            "<node><interface name='I.A'><method name='M'/></interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-removed',
-                 'Argument 0 of method ‘A.M’ has been removed.'),
+                 'Argument 0 of method ‘I.A.M’ has been removed.'),
             ])
 
     def test_method_arg_added(self):
         self.assertOutput(
-            "<node><interface name='A'><method name='M'/></interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'><method name='M'/></interface></node>",
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='s' direction='in'/></method>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-added',
-                 'Argument 0 of method ‘A.M’ has been added.'),
+                 'Argument 0 of method ‘I.A.M’ has been added.'),
             ])
 
     def test_method_arg_name_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='s' name='A' direction='in'/></method>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='s' name='Z' direction='in'/></method>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_INFO,
                  'argument-name-changed',
-                 'Argument 0 of ‘A.M’ has changed name from ‘A’ to ‘Z’.'),
+                 'Argument 0 of ‘I.A.M’ has changed name from ‘A’ to ‘Z’.'),
             ])
 
     def test_method_arg_type_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='s' direction='in'/></method>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='b' direction='in'/></method>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-type-changed',
-                 'Argument 0 of ‘A.M’ has changed type from ‘s’ to ‘b’.'),
+                 'Argument 0 of ‘I.A.M’ has changed type from ‘s’ to ‘b’.'),
             ])
 
     def test_method_arg_direction_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='s' direction='in'/></method>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<method name='M'><arg type='s' direction='out'/></method>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-direction-changed-in-out',
-                 'Argument 0 of ‘A.M’ has changed direction from ‘in’ to '
+                 'Argument 0 of ‘I.A.M’ has changed direction from ‘in’ to '
                  '‘out’.'),
             ])
 
     def test_method_c_symbol_changed(self):
         self.assertOutput(
-            "<node><interface name='A'><method name='M'>"
+            "<node><interface name='I.A'><method name='M'>"
             "<annotation name='org.freedesktop.DBus.GLib.CSymbol' value='S1'/>"
             "</method></interface></node>",
-            "<node><interface name='A'><method name='M'>"
+            "<node><interface name='I.A'><method name='M'>"
             "<annotation name='org.freedesktop.DBus.GLib.CSymbol' value='S2'/>"
             "</method></interface></node>", [
                 (None, InterfaceComparator.OUTPUT_INFO,
                  'c-symbol-changed',
-                 'Node ‘A.M’ has changed its C symbol from ‘S1’ to ‘S2’.'),
+                 'Node ‘I.A.M’ has changed its C symbol from ‘S1’ to ‘S2’.'),
             ])
 
     def test_method_no_reply_changed_to_false(self):
         self.assertOutput(
-            "<node><interface name='A'><method name='M'>"
+            "<node><interface name='I.A'><method name='M'>"
             "<annotation name='org.freedesktop.DBus.Method.NoReply' "
             "value='true'/>"
             "</method></interface></node>",
-            "<node><interface name='A'><method name='M'>"
+            "<node><interface name='I.A'><method name='M'>"
             "<annotation name='org.freedesktop.DBus.Method.NoReply' "
             "value='false'/>"
             "</method></interface></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'reply-added',
-                 'Node ‘A.M’ has been marked as returning a reply.'),
+                 'Node ‘I.A.M’ has been marked as returning a reply.'),
             ])
 
     def test_method_no_reply_changed_to_true(self):
         self.assertOutput(
-            "<node><interface name='A'><method name='M'/></interface></node>",
-            "<node><interface name='A'><method name='M'>"
+            "<node><interface name='I.A'><method name='M'/></interface></node>",
+            "<node><interface name='I.A'><method name='M'>"
             "<annotation name='org.freedesktop.DBus.Method.NoReply' "
             "value='true'/>"
             "</method></interface></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'reply-removed',
-                 'Node ‘A.M’ has been marked as not returning a reply.'),
+                 'Node ‘I.A.M’ has been marked as not returning a reply.'),
             ])
 
     def test_method_no_reply_changed_to_true_explicit(self):
         self.assertOutput(
-            "<node><interface name='A'><method name='M'>"
+            "<node><interface name='I.A'><method name='M'>"
             "<annotation name='org.freedesktop.DBus.Method.NoReply' "
             "value='false'/>"
             "</method></interface></node>",
-            "<node><interface name='A'><method name='M'>"
+            "<node><interface name='I.A'><method name='M'>"
             "<annotation name='org.freedesktop.DBus.Method.NoReply' "
             "value='true'/>"
             "</method></interface></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'reply-removed',
-                 'Node ‘A.M’ has been marked as not returning a reply.'),
+                 'Node ‘I.A.M’ has been marked as not returning a reply.'),
             ])
 
     def test_property_removed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
-            "<node><interface name='A'/></node>", [
+            "<node><interface name='I.A'/></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'property-removed',
-                 'Property ‘A.P’ has been removed.'),
+                 'Property ‘I.A.P’ has been removed.'),
             ])
 
     def test_property_added(self):
         self.assertOutput(
-            "<node><interface name='A'/></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'/></node>",
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'property-added',
-                 'Property ‘A.P’ has been added.'),
+                 'Property ‘I.A.P’ has been added.'),
             ])
 
     def test_property_name_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P2' type='b' access='readwrite'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'property-removed',
-                 'Property ‘A.P’ has been removed.'),
+                 'Property ‘I.A.P’ has been removed.'),
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'property-added',
-                 'Property ‘A.P2’ has been added.'),
+                 'Property ‘I.A.P2’ has been added.'),
             ])
 
     def test_property_type_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='s' access='readwrite'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'property-type-changed',
-                 'Property ‘A.P’ has changed type from ‘b’ to ‘s’.'),
+                 'Property ‘I.A.P’ has changed type from ‘b’ to ‘s’.'),
             ])
 
     def test_property_access_changed_r_to_rw(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='read'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'property-access-changed-read-readwrite',
-                 'Property ‘A.P’ has changed access from ‘read’ to '
+                 'Property ‘I.A.P’ has changed access from ‘read’ to '
                  '‘readwrite’, becoming less restrictive.'),
             ])
 
     def test_property_access_changed_w_to_rw(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='write'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'property-access-changed-write-readwrite',
-                 'Property ‘A.P’ has changed access from ‘write’ to '
+                 'Property ‘I.A.P’ has changed access from ‘write’ to '
                  '‘readwrite’, becoming less restrictive.'),
             ])
 
     def test_property_access_changed_r_to_w(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='read'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='write'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'property-access-changed-read-write',
-                 'Property ‘A.P’ has changed access from ‘read’ to ‘write’.'),
+                 'Property ‘I.A.P’ has changed access from ‘read’ to ‘write’.'),
             ])
 
     def test_property_access_changed_rw_to_r(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='read'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'property-access-changed-readwrite-read',
-                 'Property ‘A.P’ has changed access from ‘readwrite’ to '
+                 'Property ‘I.A.P’ has changed access from ‘readwrite’ to '
                  '‘read’.'),
             ])
 
     def test_property_access_changed_rw_to_w(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='readwrite'/>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<property name='P' type='b' access='write'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'property-access-changed-readwrite-write',
-                 'Property ‘A.P’ has changed access from ‘readwrite’ to '
+                 'Property ‘I.A.P’ has changed access from ‘readwrite’ to '
                  '‘write’.'),
             ])
 
@@ -449,31 +451,31 @@ class TestComparatorErrors(unittest.TestCase):
         # All the classes of error we expect.
         error1 = (
             InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
-            'Node ‘A.P’ started emitting '
+            'Node ‘I.A.P’ started emitting '
             'org.freedesktop.DBus.Properties.PropertiesChanged.'
         )
         error2a = (
             InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
-            'Node ‘A.P’ stopped emitting its new value in '
+            'Node ‘I.A.P’ stopped emitting its new value in '
             'org.freedesktop.DBus.Properties.PropertiesChanged.'
         )
         error2b = (
             InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
-            'Node ‘A.P’ started emitting its new value in '
+            'Node ‘I.A.P’ started emitting its new value in '
             'org.freedesktop.DBus.Properties.PropertiesChanged.'
         )
         error3 = (
             InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
-            'Node ‘A.P’ stopped emitting '
+            'Node ‘I.A.P’ stopped emitting '
             'org.freedesktop.DBus.Properties.PropertiesChanged.'
         )
         error4a = (
             InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
-            'Node ‘A.P’ stopped being a constant.'
+            'Node ‘I.A.P’ stopped being a constant.'
         )
         error4b = (
             InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
-            'Node ‘A.P’ became a constant.'
+            'Node ‘I.A.P’ became a constant.'
         )
 
         # 2D matrix of test vectors. Each row gives the old annotation value;
@@ -501,14 +503,14 @@ class TestComparatorErrors(unittest.TestCase):
                 expected_errors = [vector] if vector is not None else []
 
                 self.assertOutput(
-                    "<node><interface name='A'>"
+                    "<node><interface name='I.A'>"
                     "<property name='P' type='b' access='readwrite'>"
                     "<annotation "
                     "name='org.freedesktop.DBus.Property.EmitsChangedSignal' "
                     "value='%s'/>"
                     "</property>"
                     "</interface></node>" % labels[i],
-                    "<node><interface name='A'>"
+                    "<node><interface name='I.A'>"
                     "<property name='P' type='b' access='readwrite'>"
                     "<annotation "
                     "name='org.freedesktop.DBus.Property.EmitsChangedSignal' "
@@ -519,104 +521,104 @@ class TestComparatorErrors(unittest.TestCase):
 
     def test_signal_removed(self):
         self.assertOutput(
-            "<node><interface name='A'><signal name='S'/>"
+            "<node><interface name='I.A'><signal name='S'/>"
             "</interface></node>",
-            "<node><interface name='A'/></node>", [
+            "<node><interface name='I.A'/></node>", [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'signal-removed',
-                 'Signal ‘A.S’ has been removed.'),
+                 'Signal ‘I.A.S’ has been removed.'),
             ])
 
     def test_signal_added(self):
         self.assertOutput(
-            "<node><interface name='A'/></node>",
-            "<node><interface name='A'><signal name='S'/>"
+            "<node><interface name='I.A'/></node>",
+            "<node><interface name='I.A'><signal name='S'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'signal-added',
-                 'Signal ‘A.S’ has been added.'),
+                 'Signal ‘I.A.S’ has been added.'),
             ])
 
     def test_signal_name_changed(self):
         self.assertOutput(
-            "<node><interface name='A'><signal name='S'/>"
+            "<node><interface name='I.A'><signal name='S'/>"
             "</interface></node>",
-            "<node><interface name='A'><signal name='S2'/>"
+            "<node><interface name='I.A'><signal name='S2'/>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'signal-removed',
-                 'Signal ‘A.S’ has been removed.'),
+                 'Signal ‘I.A.S’ has been removed.'),
                 (None, InterfaceComparator.OUTPUT_FORWARDS_INCOMPATIBLE,
                  'signal-added',
-                 'Signal ‘A.S2’ has been added.'),
+                 'Signal ‘I.A.S2’ has been added.'),
             ])
 
     def test_signal_arg_removed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='s' direction='in'/></signal>"
             "</interface></node>",
-            "<node><interface name='A'><signal name='S'/></interface></node>",
+            "<node><interface name='I.A'><signal name='S'/></interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-removed',
-                 'Argument 0 of signal ‘A.S’ has been removed.'),
+                 'Argument 0 of signal ‘I.A.S’ has been removed.'),
             ])
 
     def test_signal_arg_added(self):
         self.assertOutput(
-            "<node><interface name='A'><signal name='S'/></interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'><signal name='S'/></interface></node>",
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='s' direction='in'/></signal>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-added',
-                 'Argument 0 of signal ‘A.S’ has been added.'),
+                 'Argument 0 of signal ‘I.A.S’ has been added.'),
             ])
 
     def test_signal_arg_name_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='s' name='A' direction='in'/></signal>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='s' name='Z' direction='in'/></signal>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_INFO,
                  'argument-name-changed',
-                 'Argument 0 of ‘A.S’ has changed name from ‘A’ to ‘Z’.'),
+                 'Argument 0 of ‘I.A.S’ has changed name from ‘A’ to ‘Z’.'),
             ])
 
     def test_signal_arg_type_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='s' direction='in'/></signal>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='b' direction='in'/></signal>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-type-changed',
-                 'Argument 0 of ‘A.S’ has changed type from ‘s’ to ‘b’.'),
+                 'Argument 0 of ‘I.A.S’ has changed type from ‘s’ to ‘b’.'),
             ])
 
     def test_signal_arg_direction_changed(self):
         self.assertOutput(
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='s' direction='in'/></signal>"
             "</interface></node>",
-            "<node><interface name='A'>"
+            "<node><interface name='I.A'>"
             "<signal name='S'><arg type='s' direction='out'/></signal>"
             "</interface></node>",
             [
                 (None, InterfaceComparator.OUTPUT_BACKWARDS_INCOMPATIBLE,
                  'argument-direction-changed-in-out',
-                 'Argument 0 of ‘A.S’ has changed direction from ‘in’ to '
+                 'Argument 0 of ‘I.A.S’ has changed direction from ‘in’ to '
                  '‘out’.'),
             ])
 

--- a/dbusdeviation/utilities/diff.py
+++ b/dbusdeviation/utilities/diff.py
@@ -64,7 +64,8 @@ def _parse_file(filename, parser):
     list. Print an error and exit if parsing fails.
     """
     try:
-        interfaces = parser.parse()
+        root_node = parser.parse()
+        interfaces = root_node.interfaces
 
         # Handle parse errors.
         if interfaces is None:


### PR DESCRIPTION
Added support for the < node > element. The introspection example from the D-Bus specification can be successfully parsed now.

Added interface and member (methods/signals) name validation.

Fixed minor PEP8 and pylint errors.

All review comments from pull request #5 for these changes are taken into account.
