### PR TITLE
Added support for the <node> element and object path validation.

### DIFF
--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -71,7 +71,7 @@ class Log(object):
 
     # pylint: disable=no-self-use
     def _create_entry(self, code, message):
-        return (None, self.domain, code, message)
+        return None, self.domain, code, message
 
 
 class AstLog(Log):
@@ -442,7 +442,7 @@ class Property(BaseNode):
         Args:
             name: property name; a non-empty string, not including the parent
                 interface name
-            prop_type: type string for the property; see http://goo.gl/uCpa5A
+            type_: type string for the property; see http://goo.gl/uCpa5A
             access: ACCESS_READ, ACCESS_WRITE, or ACCESS_READWRITE
             annotations: potentially empty dict of annotations applied to the
                 property, mapping annotation name to an `ast.Annotation`

--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -323,7 +323,9 @@ class Node(BaseNode):
         self._type_containers.update({Interface: self.interfaces,
                                       Node: self.nodes})
 
-        for child in (interfaces or {}).values() + (nodes or {}).values():
+        for child in (interfaces or {}).values():
+            self._add_child(child)
+        for child in (nodes or {}).values():
             self._add_child(child)
 
     def _add_child(self, child):
@@ -400,8 +402,11 @@ class Interface(BaseNode):
                                       Signal: self.signals,
                                       Property: self.properties})
 
-        for child in (methods or {}).values() + (signals or {}).values() + \
-                (properties or {}).values():
+        for child in (methods or {}).values():
+            self._add_child(child)
+        for child in (signals or {}).values():
+            self._add_child(child)
+        for child in (properties or {}).values():
             self._add_child(child)
 
     def _add_child(self, child):

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -69,7 +69,7 @@ class ParsingLog(AstLog):
         self.domain = 'parser'
 
     def _create_entry(self, code, message):
-        return (self.__filename, self.domain, code, message)
+        return self.__filename, self.domain, code, message
 
 
 class InterfaceParser(object):

--- a/dbusapi/tests/test_ast.py
+++ b/dbusapi/tests/test_ast.py
@@ -46,7 +46,7 @@ class TestAstNames(unittest.TestCase):
 
     def test_property(self):
         prop = ast.Property('AProperty', 's', ast.Property.ACCESS_READ)
-        iface = ast.Interface('SomeInterface', {}, {
+        ast.Interface('SomeInterface', {}, {
             'AProperty': prop,
         })
         self.assertEqual(prop.format_name(), 'SomeInterface.AProperty')
@@ -57,7 +57,7 @@ class TestAstNames(unittest.TestCase):
 
     def test_method(self):
         method = ast.Method('AMethod', [])
-        iface = ast.Interface('SomeInterface', {
+        ast.Interface('SomeInterface', {
             'AMethod': method,
         })
         self.assertEqual(method.format_name(), 'SomeInterface.AMethod')
@@ -68,7 +68,7 @@ class TestAstNames(unittest.TestCase):
 
     def test_signal(self):
         signal = ast.Signal('SomeSignal', [])
-        iface = ast.Interface('SomeInterface', {}, {}, {
+        ast.Interface('SomeInterface', {}, {}, {
             'SomeSignal': signal,
         })
         self.assertEqual(signal.format_name(), 'SomeInterface.SomeSignal')
@@ -79,7 +79,7 @@ class TestAstNames(unittest.TestCase):
 
     def test_argument(self):
         arg = ast.Argument('self', ast.Argument.DIRECTION_IN, 's')
-        method = ast.Method('ParentMethod', [arg])
+        ast.Method('ParentMethod', [arg])
         self.assertEqual(arg.format_name(),
                          '0 (‘self’) of method ‘ParentMethod’')
 
@@ -89,7 +89,7 @@ class TestAstNames(unittest.TestCase):
 
     def test_argument_unnamed(self):
         arg = ast.Argument(None, ast.Argument.DIRECTION_IN, 's')
-        method = ast.Method('ParentMethod', [arg])
+        ast.Method('ParentMethod', [arg])
         self.assertEqual(arg.format_name(), '0 of method ‘ParentMethod’')
 
     # pylint: disable=invalid-name
@@ -99,7 +99,7 @@ class TestAstNames(unittest.TestCase):
 
     def test_annotation_interface(self):
         annotation = ast.Annotation('SomeAnnotation', 'value')
-        iface = ast.Interface('SomeInterface', {}, {}, {}, {
+        ast.Interface('SomeInterface', {}, {}, {}, {
             'SomeAnnotation': annotation,
         })
         self.assertEqual(annotation.format_name(),
@@ -110,7 +110,7 @@ class TestAstNames(unittest.TestCase):
         prop = ast.Property('AProperty', 's', ast.Property.ACCESS_READ, {
             'SomeAnnotation': annotation,
         })
-        iface = ast.Interface('SomeInterface', {}, {
+        ast.Interface('SomeInterface', {}, {
             'AProperty': prop,
         })
         self.assertEqual(annotation.format_name(),
@@ -121,7 +121,7 @@ class TestAstNames(unittest.TestCase):
         method = ast.Method('AMethod', [], {
             'SomeAnnotation': annotation,
         })
-        iface = ast.Interface('SomeInterface', {
+        ast.Interface('SomeInterface', {
             'AMethod': method,
         })
         self.assertEqual(annotation.format_name(),
@@ -132,7 +132,7 @@ class TestAstNames(unittest.TestCase):
         signal = ast.Signal('ASignal', [], {
             'SomeAnnotation': annotation,
         })
-        iface = ast.Interface('SomeInterface', {}, {}, {
+        ast.Interface('SomeInterface', {}, {}, {
             'ASignal': signal,
         })
         self.assertEqual(annotation.format_name(),
@@ -144,7 +144,7 @@ class TestAstNames(unittest.TestCase):
             'SomeAnnotation': annotation,
         })
         method = ast.Method('AMethod', [arg])
-        iface = ast.Interface('SomeInterface', {
+        ast.Interface('SomeInterface', {
             'AMethod': method,
         })
         self.assertEqual(annotation.format_name(),


### PR DESCRIPTION
Added support for the < node > element and object path validation. The introspection example from the D-Bus specification can be successfully parsed now.

All review comments from pull request #6 are taken into account.

I plan to submit separate pull requests for:
- interface and member (methods/signals) name validation.
- type parsing
