### PR TITLE
Removed the unnecessary InterfaceParser._output

### DIFF
--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -66,6 +66,10 @@ class Log(object):
     def _create_entry(self, code, message):
         return None, self.domain, code, message
 
+    def clear(self):
+        """Clear the issue list."""
+        self.issues = []
+
 
 class AstLog(Log):
 

--- a/dbusapi/interfaceparser.py
+++ b/dbusapi/interfaceparser.py
@@ -31,21 +31,6 @@ def _skip_non_node(elem):
     return None
 
 
-def _get_root(filename, log):
-    root = etree.parse(filename).getroot()
-
-    # Handle specifications wrapped in tp:spec.
-    if root.tag == '{%s}spec' % TP_DTD:
-        root = _skip_non_node(root)
-
-    if root is not None and root.tag != 'node':
-        log.log_issue('unknown-node',
-                      'Unknown root node ‘%s’.' % root.tag)
-        root = _skip_non_node(root)
-
-    return root
-
-
 class ParsingLog(AstLog):
 
     """A specialized AstLog subclass for parsing issues"""
@@ -85,7 +70,7 @@ class InterfaceParser(object):
             filename: path to the XML introspection file to parse
         """
         self._filename = filename
-        self._output = []
+        self._log = ParsingLog(filename)
 
     @staticmethod
     def get_output_codes():
@@ -94,7 +79,21 @@ class InterfaceParser(object):
 
     def get_output(self):
         """Return a list of all logged parser messages."""
-        return self._output
+        return self._log.issues
+
+    def _get_root(self):
+        root = etree.parse(self._filename).getroot()
+
+        # Handle specifications wrapped in tp:spec.
+        if root.tag == '{%s}spec' % TP_DTD:
+            root = _skip_non_node(root)
+
+        if root is not None and root.tag != 'node':
+            self._log.log_issue('unknown-node',
+                                'Unknown root node ‘%s’.' % root.tag)
+            root = _skip_non_node(root)
+
+        return root
 
     def parse_with_nodes(self):
         """
@@ -104,25 +103,21 @@ class InterfaceParser(object):
             An ast.Node instance, representing the root node.
             If parsing fails, None is returned.
         """
-        log = ParsingLog(self._filename)
+        self._log.clear()
 
-        root = _get_root(self._filename, log)
-
+        root = self._get_root()
         if root is None:
-            self._output = log.issues
             return None
 
-        root_node = Node.from_xml(root, None, log)
+        root_node = Node.from_xml(root, None, self._log)
 
         if root_node.name and \
            not Node.is_valid_absolute_object_path(root_node.name):
-            log.log_issue('node-name',
-                          'Root node name is not an absolute object path '
-                          '‘%s’.' % root_node.name)
+            self._log.log_issue('node-name',
+                                'Root node name is not an absolute object '
+                                'path ‘%s’.' % root_node.name)
 
-        self._output = log.issues
-
-        if self._output:
+        if self._log.issues:
             return None
 
         return root_node


### PR DESCRIPTION
Replaced the unnecessary InterfaceParser._output property with _log - an instance of ParserLog.

I was very tempted to make InterfaceParser.get_output_codes() non-static but stopped short of making this interface break.

On a separate note, I plan to move the Log class to a separate file to reuse it in the type parser. OK?