### PR TITLE
dbusapi/ast: Expose line numbers.

### DIFF
--- a/dbusapi/ast.py
+++ b/dbusapi/ast.py
@@ -92,6 +92,8 @@ class BaseNode(object):
         self._comment = None
         self.log = log or AstLog()
         self.annotations = OrderedDict()
+        self.lineno = -1
+        self.comment_lineno = -1
 
         self._children_types = {
             'annotation': Annotation,
@@ -139,7 +141,15 @@ class BaseNode(object):
 
         attrs['log'] = log
         res = cls(**attrs)
-        res.comment = comment
+        res.lineno = node.sourceline
+        if comment is not None:
+            res.comment = comment.text
+            # lxml reports the last source line for xml comments as
+            # being the actual source line, fix this.
+            # Also report line numbers starting from 1, consistent
+            # with node.lineno
+            res.comment_lineno = (comment.sourceline -
+                                  len(res.comment.split('\n')) + 1)
 
         if parent:
             parent.add_child(res)
@@ -156,10 +166,11 @@ class BaseNode(object):
         xml_comment = None
         for elem in node:
             if elem.tag == etree.Comment:
-                xml_comment = elem.text
+                xml_comment = elem
                 continue
 
             elif elem.tag in BaseNode.DOCSTRING_TAGS:
+                self.comment_lineno = elem.sourceline
                 self.comment = elem.text
                 continue
 

--- a/dbusapi/tests/test_interfaceparser.py
+++ b/dbusapi/tests/test_interfaceparser.py
@@ -447,6 +447,41 @@ class TestParserNormal(unittest.TestCase):
         arg = meth.arguments[0]
         self.assertEquals(arg.comment, "And me!")
 
+    def test_linenos(self):
+        """Test that line numbers are correctly computed"""
+        xml = ("<node xmlns:tp='"
+               "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
+               "' xmlns:doc='"
+               "http://www.freedesktop.org/dbus/1.0/doc.dtd'>\n"
+               "<!--\n"
+               "Please consider me\n"
+               "-->\n"
+               "<interface name='I.I'>\n"
+               "<!--\n"
+               "Notice me too\n"
+               "-->\n"
+               "<method name='foo'>\n"
+               "<!--\n"
+               "And me!\n"
+               "-->\n"
+               "<arg name='bar' type='s'/>\n"
+               "</method>\n"
+               "</interface></node>\n")
+
+        (parser, interfaces, _) = _test_parser(xml)
+        interface = interfaces.get('I.I')
+        self.assertIsNotNone(interface)
+        self.assertEqual(interface.lineno, 5)
+        self.assertEqual(interface.comment_lineno, 2)
+        meth = interface.methods.get('foo')
+        self.assertIsNotNone(meth)
+        self.assertEqual(meth.lineno, 9)
+        self.assertEqual(meth.comment_lineno, 6)
+        self.assertEquals(len(meth.arguments), 1)
+        arg = meth.arguments[0]
+        self.assertEqual(arg.lineno, 13)
+        self.assertEqual(arg.comment_lineno, 10)
+
     def test_doc_annotations(self):
         xml = ("<node xmlns:tp='"
                "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"


### PR DESCRIPTION
Both for nodes and their comments.

Fixes https://github.com/pwithnall/dbus-deviation/issues/3

This can be later used for exposing better error messages, but that is out of scope.
