### PR TITLE
build: Use pycodestyle rather than setuptools_pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-# Disabled due to lxml 3.5.0 not working with PyPy:
-# See: https://bitbucket.org/pypy/compatibility/wiki/lxml
-#  - "pypy"
+  - "pypy3"
 # command to install dependencies
 install:
   - pip install pylint coverage coveralls codecov pycodestyle .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 # Disabled due to lxml 3.5.0 not working with PyPy:
 # See: https://bitbucket.org/pypy/compatibility/wiki/lxml
 #  - "pypy"
-# Disabled due to bugs in the logilab package on the Python 3.2 build slave.
-# See: https://travis-ci.org/pwithnall/dbus-deviation/jobs/60500460
-#  - "3.2"
 # command to install dependencies
 install:
   - pip install pylint coverage coveralls codecov pycodestyle .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,14 @@ python:
 #  - "3.2"
 # command to install dependencies
 install:
-  - pip install pylint coverage coveralls codecov .
+  - pip install pylint coverage coveralls codecov pycodestyle .
 # command to run tests
 script:
   - coverage run --source dbusapi,dbusdeviation --omit 'dbusdeviation/utilities/*' setup.py test
   - coverage report --fail-under=70
   - python setup.py check
-  - python setup.py pep8
+  - pycodestyle dbusapi
+  - pycodestyle dbusdeviation
   - pylint --errors-only dbusapi
   - pylint --errors-only dbusdeviation
 # Submit coverage data to coveralls.io and codecov.io

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-Philip Withnall <philip.withnall@collabora.co.uk>
+Philip Withnall <philip@tecnocode.co.uk>

--- a/README
+++ b/README
@@ -101,5 +101,5 @@ https://gitlab.com/dbus-deviation/dbus-deviation
 Contact
 =======
 
-Philip Withnall <philip.withnall@collabora.co.uk>
-http://people.collabora.com/~pwith/dbus-deviation/
+Philip Withnall <philip@tecnocode.co.uk>
+https://tecnocode.co.uk/dbus-deviation/

--- a/dbus-deviation.doap
+++ b/dbus-deviation.doap
@@ -4,11 +4,11 @@
 	<description xml:lang="en">dbus-deviation is a project for parsing D-Bus introspection XML and processing it in various ways. Its main tool is dbus-interface-diff, which calculates the difference between two D-Bus APIs for the purpose of checking for API breaks. This functionality is also available as a Python module, dbusdeviation.</description>
 	<homepage rdf:resource="https://gitlab.com/dbus-deviation/"/>
 	<license rdf:resource="http://usefulinc.com/doap/licenses/lgpl"/>
-	<download-page rdf:resource="http://people.collabora.com/~pwith/dbus-deviation/"/>
+	<download-page rdf:resource="https://tecnocode.co.uk/dbus-deviation/errors.html"/>
 	<maintainer>
 		<foaf:Person>
 			<foaf:name>Philip Withnall</foaf:name>
-			<foaf:mbox rdf:resource="mailto:philip.withnall@collabora.co.uk"/>
+			<foaf:mbox rdf:resource="mailto:philip@tecnocode.co.uk"/>
 		</foaf:Person>
 	</maintainer>
 </Project>

--- a/dbusdeviation/utilities/diff.py
+++ b/dbusdeviation/utilities/diff.py
@@ -233,5 +233,6 @@ def main():
     _print_output(out)
     sys.exit(_calculate_exit_status(args, out))
 
+
 if __name__ == '__main__':
     main()

--- a/dbusdeviation/utilities/diff.py
+++ b/dbusdeviation/utilities/diff.py
@@ -120,8 +120,7 @@ def _print_output(output, include_uris=True, enable_colour=True):
     for (filename, level, code, message) in output:
         formatted_level = _format_level(level, enable_colour, max_level_len)
         fd_for_level = _get_fd_for_level(level)
-        errors_page = 'https://people.collabora.com' \
-                      '/~pwith/dbus-deviation/errors.html'
+        errors_page = 'https://tecnocode.co.uk/dbus-deviation/errors.html'
         explanation_uri = '%s#%s' % (errors_page, code)
         formatted_code = code.rjust(max_code_len)
 

--- a/dbusdeviation/utilities/vcs_helper.py
+++ b/dbusdeviation/utilities/vcs_helper.py
@@ -412,7 +412,6 @@ def main():
     parser.add_argument('--silent', action='store_const', const=True,
                         default=False,
                         help='Silence all non-error output')
-    # pylint: disable=bad-continuation
     parser.add_argument('--git', type=str, default='git', metavar='COMMAND',
                         help='Path to the git command, including extra '
                              'arguments')
@@ -425,7 +424,6 @@ def main():
     parser.add_argument('--git-remote', dest='git_remote_origin', type=str,
                         default='origin', metavar='REMOTE',
                         help='git remote to push notes to')
-    # pylint: disable=bad-continuation
     parser.add_argument('--git-refs', dest='dbus_api_git_refs', type=str,
                         default='notes/dbus/api', metavar='REF-PATH',
                         help='Path beneath refs/ where the git notes will be'
@@ -457,7 +455,6 @@ def main():
     parser_check.add_argument('--fatal-warnings', action='store_const',
                               const=True, default=False,
                               help='Treat all warnings as fatal')
-    # pylint: disable=bad-continuation
     parser_check.add_argument('old_ref', metavar='OLD-REF',
                               type=str, nargs='?', default='',
                               help='Old ref to compare; or empty for the '

--- a/dbusdeviation/utilities/vcs_helper.py
+++ b/dbusdeviation/utilities/vcs_helper.py
@@ -488,5 +488,6 @@ def main():
 
     return args.func(args)
 
+
 if __name__ == '__main__':
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pep8]
+[pycodestyle]
 exclude = *.egg,docs/conf.py,version.py,setup.py

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ setup(
     zip_safe=True,
     setup_requires=[
         'setuptools_git >= 0.3',
-        'setuptools_pep8',
         'sphinx',
     ],
     install_requires=['lxml'],

--- a/setup.py
+++ b/setup.py
@@ -106,11 +106,11 @@ setup(
         ],
     },
     author=project_author,
-    author_email='philip.withnall@collabora.co.uk',
+    author_email='philip@tecnocode.co.uk',
     description=__doc__,
     long_description=README + '\n\n' + NEWS,
     license='LGPLv2.1+',
-    url='http://people.collabora.com/~pwith/dbus-deviation/',
+    url='https://tecnocode.co.uk/dbus-deviation/',
     cmdclass={'test': DiscoverTest},
     command_options={
         'build_sphinx': {


### PR DESCRIPTION
The latter is unmaintained and was complicating setup.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: #18