### PR TITLE
docs: Rename a few instances of ‘master’

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. dbus-deviation documentation master file, created by
+.. dbus-deviation documentation main file, created by
    sphinx-quickstart on Wed Apr 29 10:22:21 2015.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/website/index.html
+++ b/website/index.html
@@ -62,7 +62,7 @@ cd ./dbus-deviation-<span class="replaceable">$VERSION</span>
 <h2 id="documentation">Documentation</h2>
 
 <p>For installation and quick-start information, see the
-   <a href="https://github.com/pwithnall/dbus-deviation/blob/master/README.md" title="README for dbus-deviation.">README
+   <a href="https://github.com/pwithnall/dbus-deviation/blob/HEAD/README.md" title="README for dbus-deviation.">README
    file</a>.</p>
 
 <p>API documentation is


### PR DESCRIPTION
This matches the recent main development branch name change from
`master` to `main`.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>